### PR TITLE
Centraliza la conexión a la base de datos

### DIFF
--- a/Citas/index.php
+++ b/Citas/index.php
@@ -33,46 +33,24 @@
                 <div class="table-responsive">
 
                     <?php
-                    // Configuración de la conexión a la base de datos
-                    $host = 'localhost';
-                    $db   = 'clini234_cerene';
-                    $user = 'clini234_cerene';
-                    $pass = 'tu{]ScpQ-Vcg';
-                    $charset = 'utf8mb4';
-                    
-                    $dsn = "mysql:host=$host;dbname=$db;charset=$charset";
-                    $options = [
-                        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-                        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                        PDO::ATTR_EMULATE_PREPARES   => false,
-                    ];
-                    
-                    try {
-                        $pdo = new PDO($dsn, $user, $pass, $options);
-                    } catch (\PDOException $e) {
-                        throw new \PDOException($e->getMessage(), (int)$e->getCode());
-                    }
-
-                    $sql = "SELECT ci.id, 
-                    n.name, 
-                    us.name as Psicologo, 
-                    ci.costo, 
-                    ci.Programado, 
-                    DATE(ci.Programado) as Fecha, 
-                    TIME(ci.Programado) as Hora, 
-                    ci.Tipo, 
+                    $sql = "SELECT ci.id,
+                    n.name,
+                    us.name as Psicologo,
+                    ci.costo,
+                    ci.Programado,
+                    DATE(ci.Programado) as Fecha,
+                    TIME(ci.Programado) as Hora,
+                    ci.Tipo,
                     es.name as Estatus,
                     ci.FormaPago
                     FROM Cita ci
                     INNER JOIN nino n ON n.id = ci.IdNino
                     INNER JOIN Usuarios us ON us.id = ci.IdUsuario
                     INNER JOIN Estatus es ON es.id = ci.Estatus
-                    WHERE (ci.Estatus = 1 OR ci.Estatus = 4) 
+                    WHERE (ci.Estatus = 1 OR ci.Estatus = 4)
                     ORDER BY ci.Programado ASC;";
 
-                    $stmt = $pdo->prepare($sql);
-                    $stmt->execute();
-                    $result = $stmt->fetchAll(); // Obtener todos los resultados como un array asociativo
+                    $result = $conn->query($sql);
                     
                     // Establecer zona horaria
                     date_default_timezone_set('America/Mexico_City');
@@ -84,7 +62,7 @@
                
 
                     // Verificar si hay resultados y generar la tabla HTML
-                    if (count($result) > 0) {
+                    if ($result && $result->num_rows > 0) {
                         echo "<table border='1' id='myTable'>
                                 <thead>
                                     <tr>
@@ -102,7 +80,7 @@
                                 </thead>
                                 <tbody>";
                         // Recorrer los resultados y mostrarlos en la tabla
-                        foreach ($result as $row)  {
+                        while ($row = $result->fetch_assoc())  {
                             echo "<tr>
                                     <td>{$row['Fecha']}</td>
                                     <td>{$row['id']}</td>

--- a/Clientes/agregarNino.php
+++ b/Clientes/agregarNino.php
@@ -8,20 +8,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $FechaIngreso = $_POST['FechaIngreso'];
     $Observaciones = $_POST['Observaciones'];
 
-    // Conectar a la base de datos
-	$servername = "localhost";
-	$username = "clini234_cerene";
-	$password = "tu{]ScpQ-Vcg";
-	$dbname = "clini234_cerene";
-
-
-    // Crear conexión
-    $conn = new mysqli($servername, $username, $password, $dbname);
-    $conn->set_charset("utf8");
-    // Verificar conexión
-    if ($conn->connect_error) {
-        die("Conexión fallida: " . $conn->connect_error);
-    }
+    require_once __DIR__ . '/../conexion.php';
+    $conn = conectar();
     $conn->set_charset("utf8");
     // Preparar y vincular
     $stmt = $conn->prepare("INSERT INTO `nino`(`id`, `name`, `activo`, `edad`, `Observacion`, `FechaIngreso`, `idtutor`) VALUES (null,?,1,?,?,?,?)");

--- a/Clientes/index.php
+++ b/Clientes/index.php
@@ -75,35 +75,14 @@ include '../Modulos/head.php';
             </thead>
             <tbody>
                 <?php
-                // Configuración de la conexión a la base de datos
-                $host = 'localhost';
-                $db = 'clini234_cerene';
-                $user = 'clini234_cerene';
-                $pass = 'tu{]ScpQ-Vcg';
-                $charset = 'utf8';
-
-                $dsn = "mysql:host=$host;dbname=$db;charset=$charset";
-                $options = [
-                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                    PDO::ATTR_EMULATE_PREPARES => false,
-                ];
-
-                try {
-                    $pdo = new PDO($dsn, $user, $pass, $options);
-                } catch (\PDOException $e) {
-                    throw new \PDOException($e->getMessage(), (int) $e->getCode());
-                }
-
-                // Consulta a la base de datos
-                $sql = "SELECT c.`id`, 
-				   c.`name`, 
-				   c.`activo`, 
-				   c.`telefono`, 
-				   GROUP_CONCAT(n.name) as Pacientes, 
-				   c.`fecha` as Registro 
-			FROM `Clientes` c
-			LEFT JOIN `nino` n ON n.`idtutor` = c.`id`";
+                $sql = "SELECT c.`id`,
+                                   c.`name`,
+                                   c.`activo`,
+                                   c.`telefono`,
+                                   GROUP_CONCAT(n.name) as Pacientes,
+                                   c.`fecha` as Registro
+                       FROM `Clientes` c
+                       LEFT JOIN `nino` n ON n.`idtutor` = c.`id`";
 
                 // Definir el filtro
                 $filter = isset($_POST['filter']) ? $_POST['filter'] : 'all';
@@ -119,10 +98,10 @@ include '../Modulos/head.php';
 
                 $sql .= " GROUP BY c.`id` DESC;";
 
-                $stmt = $pdo->query($sql);
+                $result = $conn->query($sql);
 
                 // Generación de filas de la tabla
-                while ($row = $stmt->fetch()) {
+                while ($row = $result->fetch_assoc()) {
                     $acti = $row["activo"] == 1 ? 'Sí' : 'No';
                     echo '<tr>';
                     echo '<td>' . htmlspecialchars($row['id']) . '</td>';
@@ -156,6 +135,8 @@ include '../Modulos/head.php';
                       </td>';
                     echo '</tr>';
                 }
+                $result->free();
+                $conn->close();
                 ?>
             </tbody>
         </table>

--- a/Clientes/insertcliente.php
+++ b/Clientes/insertcliente.php
@@ -5,20 +5,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $telefono = $_POST['telefono'];
     $correo = $_POST['correo'];
 
-    // Conectar a la base de datos
-	$servername = "localhost";
-	$username = "clini234_cerene";
-	$password = "tu{]ScpQ-Vcg";
-	$dbname = "clini234_cerene";
-
-
-    // Crear conexión
-    $conn = new mysqli($servername, $username, $password, $dbname);
+    require_once __DIR__ . '/../conexion.php';
+    $conn = conectar();
     $conn->set_charset("utf8");
-    // Verificar conexión
-    if ($conn->connect_error) {
-        die("Conexión fallida: " . $conn->connect_error);
-    }
 
     // Preparar y vincular
     $stmt = $conn->prepare("INSERT INTO `Clientes`(`id`, `name`, `activo`, `fecha`, `telefono`, `correo`, `tipo`) VALUES (null,?,1,NOW(),?,?,0)");

--- a/Configuracion/insert.php
+++ b/Configuracion/insert.php
@@ -1,17 +1,6 @@
 <?php
-// Datos de conexión a la base de datos
-$db_host = 'localhost';
-$db_name = 'clini234_cerene';
-$db_user = 'clini234_cerene';
-$db_pass = 'tu{]ScpQ-Vcg';
-
-// Conectar a la base de datos
-$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-
-// Verificar la conexión
-if ($conn->connect_error) {
-    die("Conexión fallida: " . $conn->connect_error);
-}
+require_once __DIR__ . '/../conexion.php';
+$conn = conectar();
 
 // Obtener datos del formulario
 $name = $_POST['name'];

--- a/Configuracion/update.php
+++ b/Configuracion/update.php
@@ -1,17 +1,6 @@
 <?php
-// Datos de conexión a la base de datos
-$db_host = 'localhost';
-$db_name = 'clini234_cerene';
-$db_user = 'clini234_cerene';
-$db_pass = 'tu{]ScpQ-Vcg';
-
-// Conectar a la base de datos
-$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-
-// Verificar la conexión
-if ($conn->connect_error) {
-    die("Conexión fallida: " . $conn->connect_error);
-}
+require_once __DIR__ . '/../conexion.php';
+$conn = conectar();
 
 // Obtener datos del formulario
 $id = $_POST['id'];

--- a/Modulos/getClientes.php
+++ b/Modulos/getClientes.php
@@ -1,28 +1,13 @@
 
 <?php
-            $host = 'localhost';
-            $db   = 'clini234_cerene';
-            $user = 'clini234_cerene';
-            $pass = 'tu{]ScpQ-Vcg';
-$charset = 'utf8mb4';
-
-$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
-$options = [
-    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-    PDO::ATTR_EMULATE_PREPARES   => false,
-];
-
-try {
-    $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (\PDOException $e) {
-    throw new \PDOException($e->getMessage(), (int)$e->getCode());
-}
+require_once __DIR__ . '/../conexion.php';
+$conn = conectar();
 
 $id = $_GET['id'];
-$stmt = $pdo->prepare("SELECT c.`id`, c.`name`,c.`activo`, `telefono`, `correo`, GROUP_CONCAT(n.name) as Pasientes, c.fecha as Registro FROM `Clientes` c
-inner join nino n on n.idtutor = c.id;");
-$stmt->execute([$id]);
-$user = $stmt->fetch();
+$sql = "SELECT c.`id`, c.`name`,c.`activo`, `telefono`, `correo`, GROUP_CONCAT(n.name) as Pasientes, c.fecha as Registro FROM `Clientes` c
+inner join nino n on n.idtutor = c.id;";
+$result = $conn->query($sql);
+$user = $result->fetch_assoc();
 echo json_encode($user);
+$conn->close();
 ?>

--- a/Modulos/getPrecios.php
+++ b/Modulos/getPrecios.php
@@ -4,28 +4,12 @@
 			ini_set('display_errors', 1);
 ?>
 <?php
-            $host = 'localhost';
-            $db   = 'clini234_cerene';
-            $user = 'clini234_cerene';
-            $pass = 'tu{]ScpQ-Vcg';
-$charset = 'utf8mb4';
-
-$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
-$options = [
-    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-    PDO::ATTR_EMULATE_PREPARES   => false,
-];
-
-try {
-    $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (\PDOException $e) {
-    throw new \PDOException($e->getMessage(), (int)$e->getCode());
-}
+require_once __DIR__ . '/../conexion.php';
+$conn = conectar();
 
 $sql = "SELECT `id`, CONCAT( `name`, ': $' ,`costo` ) as name, `costo` FROM `Precios` WHERE `activo` = 1;";
-$stmt = $pdo->prepare($sql);
-$stmt->execute();
-$users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$result = $conn->query($sql);
+$users = $result->fetch_all(MYSQLI_ASSOC);
 echo json_encode($users);
+$conn->close();
 ?>

--- a/Modulos/getPsicologos.php
+++ b/Modulos/getPsicologos.php
@@ -1,28 +1,12 @@
 <?php
-            $host = 'localhost';
-            $db   = 'clini234_cerene';
-            $user = 'clini234_cerene';
-            $pass = 'tu{]ScpQ-Vcg';
-$charset = 'utf8mb4';
-
-$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
-$options = [
-    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-    PDO::ATTR_EMULATE_PREPARES   => false,
-];
-
-try {
-    $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (\PDOException $e) {
-    throw new \PDOException($e->getMessage(), (int)$e->getCode());
-}
+require_once __DIR__ . '/../conexion.php';
+$conn = conectar();
 
 $sql = "SELECT usu.`id`,Rol.name as rol, usu.`name`, `telefono`, `correo`  FROM `Usuarios` usu
 inner join Rol on Rol.id = usu.IdRol
 WHERE usu.activo = 1 AND (usu.IdRol = 2);";
-$stmt = $pdo->prepare($sql);
-$stmt->execute();
-$users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$result = $conn->query($sql);
+$users = $result->fetch_all(MYSQLI_ASSOC);
 echo json_encode($users);
+$conn->close();
 ?>

--- a/Modulos/get_roles.php
+++ b/Modulos/get_roles.php
@@ -1,17 +1,6 @@
 <?php
-// Conectar a la base de datos
-$servername = "localhost";
-$username = "clini234_cerene";
-$password = "tu{]ScpQ-Vcg";
-$dbname = "clini234_cerene";
-
-// Crear conexión
-$conn = new mysqli($servername, $username, $password, $dbname);
-$conn->set_charset("utf8");
-// Verificar conexión
-if ($conn->connect_error) {
-    die("Conexión fallida: " . $conn->connect_error);
-}
+require_once __DIR__ . '/../conexion.php';
+$conn = conectar();
 
 // Consultar los roles activos
 $sql = "SELECT id, name FROM Rol WHERE activo = 1";

--- a/Modulos/head.php
+++ b/Modulos/head.php
@@ -10,16 +10,9 @@ if (!isset($_SESSION['user']) || !isset($_SESSION['token'])) {
     header("Location: https://app.clinicacerene.com/login.php");
     exit();
 }
-    $db_host = 'localhost';
-    $db_name = 'clini234_cerene';
-    $db_user = 'clini234_cerene';
-    $db_pass = 'tu{]ScpQ-Vcg';
 
-$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-
-if ($conn->connect_error) {
-    die("Conexión fallida: " . $conn->connect_error);
-}
+require_once __DIR__ . '/../conexion.php';
+$conn = conectar();
 
 // Verificar que el token en la sesión coincida con el token en la base de datos
 $stmt = $conn->prepare("SELECT token FROM Usuarios WHERE user = ?");

--- a/Modulos/ticket.php
+++ b/Modulos/ticket.php
@@ -3,11 +3,7 @@
 ini_set('error_reporting', E_ALL);
 ini_set('display_errors', 1);
 
-// Datos de conexión a la base de datos
-$db_host = 'localhost';
-$db_name = 'clini234_cerene';
-$db_user = 'clini234_cerene';
-$db_pass = 'tu{]ScpQ-Vcg';
+require_once __DIR__ . '/../conexion.php';
 
 // Obtener el ID de la cita desde la URL
 $cita_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
@@ -17,13 +13,7 @@ if ($cita_id == 0) {
 }
 
 try {
-    // Crear conexión
-    $conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-    $conn->set_charset("utf8");
-    // Verificar conexión
-    if ($conn->connect_error) {
-        die("Conexión fallida: " . $conn->connect_error);
-    }
+    $conn = conectar();
 
     // Preparar la consulta
     $sql = "SELECT ci.id, 

--- a/Modulos/validarCita.php
+++ b/Modulos/validarCita.php
@@ -2,18 +2,8 @@
 
 ini_set('error_reporting', E_ALL);
 ini_set('display_errors', 1);
-// Configuración de la conexión a la base de datos
-$db_host = 'localhost';
-$db_name = 'clini234_cerene';
-$db_user = 'clini234_cerene';
-$db_pass = 'tu{]ScpQ-Vcg';
-
-$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-
-// Verificar conexión
-if ($conn->connect_error) {
-    die(json_encode(array('success' => false, 'message' => 'Conexión fallida: ' . $conn->connect_error)));
-}
+require_once __DIR__ . '/../conexion.php';
+$conn = conectar();
 
 // Datos del formulario
 $idPsicologo = $_POST['IdUsuario'];

--- a/Reportes/getUsu.php
+++ b/Reportes/getUsu.php
@@ -1,17 +1,8 @@
 <?php
 ini_set('error_reporting', E_ALL);
 ini_set('display_errors', 1);
-$db_host = 'localhost';
-$db_name = 'clini234_cerene';
-$db_user = 'clini234_cerene';
-$db_pass = 'tu{]ScpQ-Vcg';
-// Crear la conexión
-$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-$conn->set_charset("utf8");
-// Verificar la conexión
-if ($conn->connect_error) {
-    die("Conexión fallida: " . $conn->connect_error);
-}
+require_once __DIR__ . '/../conexion.php';
+$conn = conectar();
 
 
 

--- a/Reportes/index.php
+++ b/Reportes/index.php
@@ -4,19 +4,6 @@ $fecha_inicio = isset($_GET['fecha_inicio']) ? $_GET['fecha_inicio'] : '';
 $fecha_fin = isset($_GET['fecha_fin']) ? $_GET['fecha_fin'] : '';
 $tipoPid = isset($_GET['tipoPid']) ? $_GET['tipoPid'] : '';
 
-$db_host = 'localhost';
-$db_name = 'clini234_cerene';
-$db_user = 'clini234_cerene';
-$db_pass = 'tu{]ScpQ-Vcg';
-
-// Crear conexión
-$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-$conn->set_charset("utf8");
-// Verificar la conexión
-if ($conn->connect_error) {
-    die("Conexión fallida: " . $conn->connect_error);
-}
-
 date_default_timezone_set('America/Mexico_City');
 $hoy = date('Y-m-d');
 

--- a/Usuarios/insert_user.php
+++ b/Usuarios/insert_user.php
@@ -13,20 +13,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         die("La contraseña debe tener al menos 6 caracteres.");
     }
 
-    // Conectar a la base de datos
-	$servername = "localhost";
-	$username = "clini234_cerene";
-	$password = "tu{]ScpQ-Vcg";
-	$dbname = "clini234_cerene";
-
-
-    // Crear conexión
-    $conn = new mysqli($servername, $username, $password, $dbname);
-
-    // Verificar conexión
-    if ($conn->connect_error) {
-        die("Conexión fallida: " . $conn->connect_error);
-    }
+    require_once __DIR__ . '/../conexion.php';
+    $conn = conectar();
 
     // Preparar y vincular
     $stmt = $conn->prepare("INSERT INTO Usuarios (name, user, pass, token, activo, registro, telefono, correo, IdRol) VALUES (?, ?, ?, '', 1, NOW(), ?, ?, ?)");

--- a/Usuarios/insertuser.php
+++ b/Usuarios/insertuser.php
@@ -13,20 +13,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         die("La contraseña debe tener al menos 6 caracteres.");
     }
 
-    // Conectar a la base de datos
-	$servername = "localhost";
-	$username = "clini234_cerene";
-	$password = "tu{]ScpQ-Vcg";
-	$dbname = "clini234_cerene";
-
-
-    // Crear conexión
-    $conn = new mysqli($servername, $username, $password, $dbname);
-
-    // Verificar conexión
-    if ($conn->connect_error) {
-        die("Conexión fallida: " . $conn->connect_error);
-    }
+    require_once __DIR__ . '/../conexion.php';
+    $conn = conectar();
 
     // Preparar y vincular
     $stmt = $conn->prepare("INSERT INTO Usuarios (name, user, pass, token, activo, registro, telefono, correo, IdRol) VALUES (?, ?, ?, '', 1, NOW(), ?, ?, ?)");

--- a/cancelar.php
+++ b/cancelar.php
@@ -3,51 +3,36 @@
 ini_set('error_reporting', E_ALL);
 ini_set('display_errors', 1);
 
-$db_host = 'localhost';
-$db_name = 'clini234_cerene'; // Asegúrate de colocar el nombre de tu base de datos aquí
-$db_user = "clini234_cerene";
-$db_pass = "tu{]ScpQ-Vcg";
+require_once 'conexion.php';
+$conn = conectar();
 session_start();
 
-try {
-    $pdo = new PDO("mysql:host=$db_host;dbname=$db_name", $db_user, $db_pass);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+date_default_timezone_set('America/Mexico_City');
+$fechaActual = date('Y-m-d H:i:s'); // Formato de fecha y hora actual
 
-    date_default_timezone_set('America/Mexico_City');
-    $fechaActual = date('Y-m-d H:i:s'); // Formato de fecha y hora actual
+$idUsuario = $_SESSION['id'];
 
-    $idUsuario = $_SESSION['id'];
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    $citaId = $_POST['citaId'];
+    $estatus = $_POST['estatus'];
+    $formaPago = $_POST['formaPago'];
 
-    if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-        $citaId = $_POST['citaId'];
-        $estatus = $_POST['estatus'];
-        $formaPago = $_POST['formaPago'];
+    // Actualizar la cita con la nueva fecha programada y la forma de pago
+    $stmt = $conn->prepare("UPDATE Cita SET FormaPago = ?, Estatus = ? WHERE id = ?");
+    $stmt->bind_param('sii', $formaPago, $estatus, $citaId);
+    $stmt->execute();
+    $stmt->close();
 
-        // Actualizar la cita con la nueva fecha programada y la forma de pago
-        $sql = "UPDATE `Cita` SET  `FormaPago` = :formaPago, Estatus = :estatus WHERE `id` = :citaId";
-        $stmt = $pdo->prepare($sql);
-        $stmt->execute([
-            ':formaPago' => $formaPago,
-            ':citaId' => $citaId,
-            ':estatus' => $estatus
-        ]);
+    // Insertar en el historial de estatus
+    $stmtInsert = $conn->prepare("INSERT INTO HistorialEstatus(id, fecha, idEstatus, idCita, idUsuario) VALUES (null, ?, 3, ?, ?)");
+    $stmtInsert->bind_param('sii', $fechaActual, $citaId, $idUsuario);
+    $stmtInsert->execute();
+    $stmtInsert->close();
 
-        // Insertar en el historial de estatus
-        $sqlInsert = "INSERT INTO `HistorialEstatus`(`id`, `fecha`, `idEstatus`, `idCita`, `idUsuario`) VALUES (null, :fecha, 3, :idCita, :idUsuario)";
-        $stmtInsert = $pdo->prepare($sqlInsert);
-        $stmtInsert->execute([
-            ':fecha' => $fechaActual,
-            ':idCita' => $citaId,
-            ':idUsuario' => $idUsuario
-        ]);
-
-        echo "Fecha de cita y forma de pago actualizadas correctamente.";
-        header("Location: index.php");
-        exit;
-    }
-} catch (PDOException $e) {
-    echo "Error: " . $e->getMessage();
+    echo "Fecha de cita y forma de pago actualizadas correctamente.";
+    header("Location: index.php");
+    exit;
 }
 
-$pdo = null;
+$conn->close();
 ?>

--- a/conexion.php
+++ b/conexion.php
@@ -1,0 +1,17 @@
+<?php
+function conectar() {
+    $db_host = 'localhost';
+    $db_name = 'clini234_cerene';
+    $db_user = 'clini234_cerene';
+    $db_pass = 'tu{]ScpQ-Vcg';
+
+    $conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
+    $conn->set_charset("utf8");
+
+    if ($conn->connect_error) {
+        die("Conexión fallida: " . $conn->connect_error);
+    }
+
+    return $conn;
+}
+?>

--- a/getRoles.php
+++ b/getRoles.php
@@ -1,19 +1,8 @@
 <?php
 // getRoles.php
 
-    // Conectar a la base de datos
-	$servername = "localhost";
-	$username = "clini234_cerene";
-	$password = "tu{]ScpQ-Vcg";
-	$dbname = "clini234_cerene";
-
-// Crear conexión
-$conn = new mysqli($servername, $username, $password, $dbname);
-$conn->set_charset("utf8");
-// Verificar conexión
-if ($conn->connect_error) {
-    die("Conexión fallida: " . $conn->connect_error);
-}
+require_once 'conexion.php';
+$conn = conectar();
 
 // Consulta SQL
 $sql = "SELECT id, name FROM Rol";

--- a/get_names.php
+++ b/get_names.php
@@ -3,28 +3,12 @@
 			ini_set('display_errors', 1);
 ?>
 <?php
-            $host = 'localhost';
-            $db   = 'clini234_cerene';
-            $user = 'clini234_cerene';
-            $pass = 'tu{]ScpQ-Vcg';
-$charset = 'utf8mb4';
-
-$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
-$options = [
-    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-    PDO::ATTR_EMULATE_PREPARES   => false,
-];
-
-try {
-    $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (\PDOException $e) {
-    throw new \PDOException($e->getMessage(), (int)$e->getCode());
-}
+require_once 'conexion.php';
+$conn = conectar();
 
 $sql = "SELECT nin.id, CONCAT ( nin.name, ' Tutor: ', cli.name) AS name FROM nino nin INNER JOIN Clientes cli ON nin.idtutor = cli.id WHERE nin.activo = 1 AND cli.activo=1;";
-$stmt = $pdo->prepare($sql);
-$stmt->execute();
-$users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$result = $conn->query($sql);
+$users = $result->fetch_all(MYSQLI_ASSOC);
 echo json_encode($users);
+$conn->close();
 ?>

--- a/index.php
+++ b/index.php
@@ -14,20 +14,6 @@ include 'Modulos/head.php';
         <div class="table-responsive">
 
           <?php
-          // Configuración de la conexión a la base de datos
-          $db_host = 'localhost';
-          $db_name = 'clini234_cerene';
-          $db_user = 'clini234_cerene';
-          $db_pass = 'tu{]ScpQ-Vcg';
-
-          // Crear conexión
-          $conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-          $conn->set_charset("utf8");
-          // Verificar la conexión
-          if ($conn->connect_error) {
-            die("Conexión fallida: " . $conn->connect_error);
-          }
-
           // Consulta SQL
           $sql = "SELECT ci.id, 
        n.name, 

--- a/login.php
+++ b/login.php
@@ -4,18 +4,9 @@ session_start();
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $user = $_POST['user'];
     $pass = $_POST['pass'];
-	
-    $db_host = 'localhost';
-    $db_name = 'clini234_cerene';
-    $db_user = 'clini234_cerene';
-    $db_pass = 'tu{]ScpQ-Vcg';
 
-    // Conexión a la base de datos
-    $conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-
-    if ($conn->connect_error) {
-        die("Conexión fallida: " . $conn->connect_error);
-    }
+    require_once 'conexion.php';
+    $conn = conectar();
 
     // Verificar las credenciales del usuario
     $stmt = $conn->prepare("SELECT id, pass, IdRol FROM Usuarios WHERE user = ?");

--- a/procesar_cita.php
+++ b/procesar_cita.php
@@ -13,44 +13,41 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
         }
     }
 
-    $host = 'localhost';
-    $db = 'clini234_cerene';
-    $user = 'clini234_cerene';
-    $pass = 'tu{]ScpQ-Vcg';
+    require_once 'conexion.php';
+    $conn = conectar();
+    $conn->set_charset('utf8');
 
-    try {
-        $conn = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
-        $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $conn->exec("set names utf8mb3");
-
-        $sql = "INSERT INTO Cita (id, IdNino, IdUsuario, idGenerado, fecha, costo, Programado, Estatus, Tipo) 
+    $sql = "INSERT INTO Cita (id, IdNino, IdUsuario, idGenerado, fecha, costo, Programado, Estatus, Tipo)
                 VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?)";
 
-        $stmt = $conn->prepare($sql);
+    $idCliente = $_POST['sendIdCliente'];
+    $idPsicologo = $_POST['sendIdPsicologo'];
+    $tipo = $_POST['resumenTipo'];
+    $fechaCita = $_POST['resumenFecha'];
+    $idGenerado = $_SESSION['id'];
+    $estatus = 2;
+    $fechaActual = date('Y-m-d H:i:s');
+    $costo = $_POST['resumenCosto'];
 
-        $idCliente = $_POST['sendIdCliente'];
-        $idPsicologo = $_POST['sendIdPsicologo'];
-        $tipo = $_POST['resumenTipo'];
-        $fechaCita = $_POST['resumenFecha'];
-        $idGenerado = $_SESSION['id'];
-        $estatus = 2;
-        $fechaActual = date('Y-m-d H:i:s');
-        $costo = $_POST['resumenCosto'];
-
-        // Revisión rápida: evitar duplicados con misma fecha y usuario
-        $check = $conn->prepare("SELECT COUNT(*) FROM Cita WHERE IdNino = ? AND Programado = ?");
-        $check->execute([$idCliente, $fechaCita]);
-        if ($check->fetchColumn() > 0) {
-            echo json_encode(['success' => false, 'message' => 'Ya existe una cita registrada para este paciente en esa fecha y hora.']);
-            exit;
-        }
-
-        $stmt->execute([$idCliente, $idPsicologo, $idGenerado, $fechaActual, $costo, $fechaCita, $estatus, $tipo]);
-
-        echo json_encode(['success' => true]);
-    } catch (PDOException $e) {
-        echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+    // Revisión rápida: evitar duplicados con misma fecha y usuario
+    $check = $conn->prepare("SELECT COUNT(*) FROM Cita WHERE IdNino = ? AND Programado = ?");
+    $check->bind_param('is', $idCliente, $fechaCita);
+    $check->execute();
+    $check->bind_result($count);
+    $check->fetch();
+    $check->close();
+    if ($count > 0) {
+        echo json_encode(['success' => false, 'message' => 'Ya existe una cita registrada para este paciente en esa fecha y hora.']);
+        exit;
     }
+
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param('iiisdsis', $idCliente, $idPsicologo, $idGenerado, $fechaActual, $costo, $fechaCita, $estatus, $tipo);
+    $stmt->execute();
+    $stmt->close();
+
+    echo json_encode(['success' => true]);
+    $conn->close();
 } else {
     echo json_encode(['success' => false, 'message' => 'Método no permitido']);
 }

--- a/querylab.php
+++ b/querylab.php
@@ -1,16 +1,6 @@
 <?php
-// Conexión a la base de datos
-     $servername = "localhost";
-     $username = "clini234_cerene";
-     $password = "tu{]ScpQ-Vcg";
-     $dbname = "clini234_cerene";
-
-$conn = new mysqli($servername, $username, $password, $dbname);
-
-// Verificar conexión
-if ($conn->connect_error) {
-    die("Error de conexión: " . $conn->connect_error);
-}
+require_once 'conexion.php';
+$conn = conectar();
 
 // Procesar consulta si se envió el formulario
 $results = [];

--- a/update.php
+++ b/update.php
@@ -3,42 +3,32 @@
 ini_set('error_reporting', E_ALL);
 ini_set('display_errors', 1);
 
-
-$db_host = 'localhost';
-$db_name = 'clini234_cerene'; // Asegúrate de colocar el nombre de tu base de datos aquí
-$db_user = "clini234_cerene";
-$db_pass = "tu{]ScpQ-Vcg";
+require_once 'conexion.php';
+$conn = conectar();
 session_start();
-try {
-    $pdo = new PDO("mysql:host=$db_host;dbname=$db_name", $db_user, $db_pass);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-    date_default_timezone_set('America/Mexico_City');
-    $fechaActual = date('Y-m-d H:i:s'); // Formato de fecha y hora actual
+date_default_timezone_set('America/Mexico_City');
+$fechaActual = date('Y-m-d H:i:s'); // Formato de fecha y hora actual
 
-    $idUsuario = $_SESSION['id'];
+$idUsuario = $_SESSION['id'];
 
-    if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-        $citaId = $_POST['citaId'];
-        $fechaProgramada = $_POST['fechaProgramada'];
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    $citaId = $_POST['citaId'];
+    $fechaProgramada = $_POST['fechaProgramada'];
 
-        $sql = "UPDATE `Cita` SET `Programado` = :fechaProgramada, Estatus = 3 WHERE `id` = :citaId";
-        $stmt = $pdo->prepare($sql);
-        $stmt->execute([':fechaProgramada' => $fechaProgramada, ':citaId' => $citaId]);
+    $stmt = $conn->prepare("UPDATE Cita SET Programado = ?, Estatus = 3 WHERE id = ?");
+    $stmt->bind_param('si', $fechaProgramada, $citaId);
+    $stmt->execute();
+    $stmt->close();
 
-        $sqlInsert = "INSERT INTO `HistorialEstatus`(`id`, `fecha`, `idEstatus`, `idCita`, `idUsuario`) VALUES (null, :fecha, 3, :idCita, :idUsuario)";
-        $stmtInsert = $pdo->prepare($sqlInsert);
-        $stmtInsert->execute([
-            ':fecha' => $fechaActual,
-            ':idCita' => $citaId,
-            ':idUsuario' => $idUsuario
-        ]);
+    $stmtInsert = $conn->prepare("INSERT INTO HistorialEstatus(id, fecha, idEstatus, idCita, idUsuario) VALUES (null, ?, 3, ?, ?)");
+    $stmtInsert->bind_param('sii', $fechaActual, $citaId, $idUsuario);
+    $stmtInsert->execute();
+    $stmtInsert->close();
 
-        echo "Fecha de cita actualizada correctamente.";header("Location:index.php");
-    }
-} catch (PDOException $e) {
-    echo "Error: " . $e->getMessage();
+    echo "Fecha de cita actualizada correctamente.";
+    header("Location:index.php");
 }
 
-$pdo = null;
+$conn->close();
 ?>


### PR DESCRIPTION
## Resumen
- Unifica el acceso a la base de datos mediante `conexion.php` y la función `conectar()`.
- Actualiza múltiples módulos para reutilizar la conexión centralizada.

## Pruebas
- `php -l Citas/index.php Clientes/agregarNino.php Clientes/index.php Clientes/insertcliente.php Configuracion/insert.php Configuracion/update.php Modulos/getClientes.php Modulos/getPrecios.php Modulos/getPsicologos.php Modulos/get_roles.php Modulos/head.php Modulos/ticket.php Modulos/validarCita.php Reportes/getUsu.php Reportes/imprimir.php Reportes/index.php Usuarios/insert_user.php Usuarios/insertuser.php cancelar.php getRoles.php get_names.php index.php login.php procesar_cita.php querylab.php update.php`

------
https://chatgpt.com/codex/tasks/task_e_688fe62c73d88322b7d3967f7037caba