### PR TITLE
Agregar flujo de aprobación de reprogramaciones

### DIFF
--- a/Citas/procesar_solicitud.php
+++ b/Citas/procesar_solicitud.php
@@ -1,0 +1,120 @@
+<?php
+ini_set('error_reporting', E_ALL);
+ini_set('display_errors', 1);
+
+require_once '../conexion.php';
+session_start();
+
+if (!isset($_SESSION['user']) || !isset($_SESSION['token'])) {
+    header('Location: /login.php');
+    exit;
+}
+
+$rolUsuario = $_SESSION['rol'] ?? 0;
+if (!in_array($rolUsuario, [3, 4], true)) {
+    $_SESSION['solicitud_mensaje'] = 'No tienes permisos para procesar solicitudes.';
+    $_SESSION['solicitud_tipo'] = 'danger';
+    header('Location: solicitudes.php');
+    exit;
+}
+
+$conn = conectar();
+
+date_default_timezone_set('America/Mexico_City');
+$fechaActual = date('Y-m-d H:i:s');
+$idUsuario = $_SESSION['id'] ?? null;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    $_SESSION['solicitud_mensaje'] = 'Solicitud inválida.';
+    $_SESSION['solicitud_tipo'] = 'danger';
+    header('Location: solicitudes.php');
+    exit;
+}
+
+$solicitudId = isset($_POST['solicitud_id']) ? (int) $_POST['solicitud_id'] : 0;
+$action = $_POST['action'] ?? '';
+$comentarios = trim($_POST['comentarios'] ?? '');
+
+if ($solicitudId <= 0 || !in_array($action, ['approve', 'reject'], true)) {
+    $_SESSION['solicitud_mensaje'] = 'Parámetros incompletos.';
+    $_SESSION['solicitud_tipo'] = 'danger';
+    header('Location: solicitudes.php');
+    exit;
+}
+
+$stmtSolicitud = $conn->prepare('SELECT cita_id, nueva_fecha, estatus FROM SolicitudReprogramacion WHERE id = ?');
+$stmtSolicitud->bind_param('i', $solicitudId);
+$stmtSolicitud->execute();
+$stmtSolicitud->bind_result($citaId, $nuevaFecha, $estatusActual);
+
+if (!$stmtSolicitud->fetch()) {
+    $stmtSolicitud->close();
+    $_SESSION['solicitud_mensaje'] = 'No se encontró la solicitud especificada.';
+    $_SESSION['solicitud_tipo'] = 'danger';
+    header('Location: solicitudes.php');
+    exit;
+}
+$stmtSolicitud->close();
+
+if ($estatusActual !== 'pendiente') {
+    $_SESSION['solicitud_mensaje'] = 'La solicitud ya fue atendida.';
+    $_SESSION['solicitud_tipo'] = 'warning';
+    header('Location: solicitudes.php');
+    exit;
+}
+
+$conn->begin_transaction();
+
+try {
+    if ($action === 'approve') {
+        $stmtUpdate = $conn->prepare('UPDATE Cita SET Programado = ?, Estatus = 3 WHERE id = ?');
+        $stmtUpdate->bind_param('si', $nuevaFecha, $citaId);
+        $stmtUpdate->execute();
+        if ($stmtUpdate->errno) {
+            throw new Exception('No fue posible actualizar la cita.');
+        }
+        $stmtUpdate->close();
+
+        $stmtHistorial = $conn->prepare('INSERT INTO HistorialEstatus(id, fecha, idEstatus, idCita, idUsuario) VALUES (null, ?, 3, ?, ?)');
+        $stmtHistorial->bind_param('sii', $fechaActual, $citaId, $idUsuario);
+        $stmtHistorial->execute();
+        if ($stmtHistorial->errno) {
+            throw new Exception('No se pudo registrar el historial de la cita.');
+        }
+        $stmtHistorial->close();
+
+        $comentariosFinal = $comentarios !== '' ? $comentarios : '';
+        $stmtFinalizar = $conn->prepare("UPDATE SolicitudReprogramacion SET estatus = 'aprobada', aprobado_por = ?, fecha_respuesta = ?, comentarios = ? WHERE id = ?");
+        $stmtFinalizar->bind_param('issi', $idUsuario, $fechaActual, $comentariosFinal, $solicitudId);
+        $stmtFinalizar->execute();
+        if ($stmtFinalizar->errno) {
+            throw new Exception('No se pudo actualizar la solicitud.');
+        }
+        $stmtFinalizar->close();
+
+        $conn->commit();
+        $_SESSION['solicitud_mensaje'] = 'Solicitud aprobada y cita reprogramada correctamente.';
+        $_SESSION['solicitud_tipo'] = 'success';
+    } else {
+        $comentariosFinal = $comentarios !== '' ? $comentarios : '';
+        $stmtRechazar = $conn->prepare("UPDATE SolicitudReprogramacion SET estatus = 'rechazada', aprobado_por = ?, fecha_respuesta = ?, comentarios = ? WHERE id = ?");
+        $stmtRechazar->bind_param('issi', $idUsuario, $fechaActual, $comentariosFinal, $solicitudId);
+        $stmtRechazar->execute();
+        if ($stmtRechazar->errno) {
+            throw new Exception('No se pudo rechazar la solicitud.');
+        }
+        $stmtRechazar->close();
+
+        $conn->commit();
+        $_SESSION['solicitud_mensaje'] = 'Solicitud rechazada correctamente.';
+        $_SESSION['solicitud_tipo'] = 'info';
+    }
+} catch (Exception $exception) {
+    $conn->rollback();
+    $_SESSION['solicitud_mensaje'] = 'Ocurrió un error al procesar la solicitud: ' . $exception->getMessage();
+    $_SESSION['solicitud_tipo'] = 'danger';
+}
+
+$conn->close();
+header('Location: solicitudes.php');
+exit;

--- a/Citas/solicitudes.php
+++ b/Citas/solicitudes.php
@@ -1,0 +1,181 @@
+<?php
+include '../Modulos/head.php';
+
+$rolUsuario = $_SESSION['rol'] ?? 0;
+$mensaje = $_SESSION['solicitud_mensaje'] ?? null;
+$tipoMensaje = $_SESSION['solicitud_tipo'] ?? 'success';
+unset($_SESSION['solicitud_mensaje'], $_SESSION['solicitud_tipo']);
+
+if (!in_array($rolUsuario, [3, 4])) {
+    ?>
+    <div class="container mt-4">
+        <div class="alert alert-danger">No tienes permisos para acceder a esta sección.</div>
+    </div>
+    <?php
+    include '../Modulos/footer.php';
+    exit;
+}
+
+$sql = "SELECT sr.id,
+       sr.cita_id,
+       sr.fecha_anterior,
+       sr.nueva_fecha,
+       sr.estatus,
+       sr.fecha_solicitud,
+       sr.fecha_respuesta,
+       sr.comentarios,
+       c.Programado AS fecha_actual_cita,
+       n.name AS paciente,
+       usuP.name AS psicologo,
+       solicitante.name AS solicitante,
+       aprobador.name AS aprobador
+FROM SolicitudReprogramacion sr
+INNER JOIN Cita c ON c.id = sr.cita_id
+INNER JOIN nino n ON n.id = c.IdNino
+INNER JOIN Usuarios usuP ON usuP.id = c.IdUsuario
+INNER JOIN Usuarios solicitante ON solicitante.id = sr.solicitado_por
+LEFT JOIN Usuarios aprobador ON aprobador.id = sr.aprobado_por
+ORDER BY sr.fecha_solicitud DESC";
+
+$resultSolicitudes = $conn->query($sql);
+if ($resultSolicitudes === false) {
+    $errorMensaje = $conn->error;
+}
+?>
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title">Solicitudes de reprogramación</h4>
+            </div>
+            <div class="card-body">
+                <?php if ($mensaje): ?>
+                    <div class="alert alert-<?php echo htmlspecialchars($tipoMensaje, ENT_QUOTES, 'UTF-8'); ?> alert-dismissible fade show" role="alert">
+                        <?php echo htmlspecialchars($mensaje, ENT_QUOTES, 'UTF-8'); ?>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                <?php endif; ?>
+
+                <?php if (isset($errorMensaje)): ?>
+                    <div class="alert alert-danger" role="alert">
+                        Error al cargar las solicitudes: <?php echo htmlspecialchars($errorMensaje, ENT_QUOTES, 'UTF-8'); ?>
+                    </div>
+                <?php else: ?>
+                    <div class="table-responsive">
+                        <table class="table" id="solicitudesTable">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Cita</th>
+                                    <th>Paciente</th>
+                                    <th>Psicólogo</th>
+                                    <th>Fecha anterior</th>
+                                    <th>Nueva fecha</th>
+                                    <th>Solicitó</th>
+                                    <th>Estatus</th>
+                                    <th>Fecha solicitud</th>
+                                    <th>Respuesta</th>
+                                    <th>Comentarios</th>
+                                    <th>Acciones</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php while ($row = $resultSolicitudes->fetch_assoc()): ?>
+                                    <?php
+                                        $estatus = $row['estatus'];
+                                        $badgeClass = 'bg-secondary';
+                                        $estatusTexto = 'Desconocido';
+                                        switch ($estatus) {
+                                            case 'pendiente':
+                                                $badgeClass = 'bg-warning text-dark';
+                                                $estatusTexto = 'Pendiente';
+                                                break;
+                                            case 'aprobada':
+                                                $badgeClass = 'bg-success';
+                                                $estatusTexto = 'Aprobada';
+                                                break;
+                                            case 'rechazada':
+                                                $badgeClass = 'bg-danger';
+                                                $estatusTexto = 'Rechazada';
+                                                break;
+                                        }
+
+                                        $comentarios = $row['comentarios'] ?? '';
+                                        $comentarios = trim($comentarios) !== '' ? $comentarios : 'Sin comentarios';
+                                        $fechaRespuesta = $row['fecha_respuesta'] ? $row['fecha_respuesta'] : '-';
+                                        $aprobador = $row['aprobador'] ? $row['aprobador'] : '-';
+                                    ?>
+                                    <tr>
+                                        <td><?php echo (int) $row['id']; ?></td>
+                                        <td><?php echo (int) $row['cita_id']; ?></td>
+                                        <td><?php echo htmlspecialchars($row['paciente'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($row['psicologo'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($row['fecha_anterior'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($row['nueva_fecha'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($row['solicitante'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><span class="badge <?php echo $badgeClass; ?>"><?php echo $estatusTexto; ?></span></td>
+                                        <td><?php echo htmlspecialchars($row['fecha_solicitud'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td>
+                                            <?php if ($fechaRespuesta !== '-'): ?>
+                                                <?php echo htmlspecialchars($fechaRespuesta, ENT_QUOTES, 'UTF-8'); ?><br>
+                                                <small><?php echo htmlspecialchars($aprobador, ENT_QUOTES, 'UTF-8'); ?></small>
+                                            <?php else: ?>
+                                                -
+                                            <?php endif; ?>
+                                        </td>
+                                        <td><?php echo htmlspecialchars($comentarios, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td>
+                                            <?php if ($estatus === 'pendiente'): ?>
+                                                <div class="d-flex flex-column gap-2">
+                                                    <form method="post" action="procesar_solicitud.php" onsubmit="return confirm('¿Deseas aprobar la solicitud?');">
+                                                        <input type="hidden" name="solicitud_id" value="<?php echo (int) $row['id']; ?>">
+                                                        <input type="hidden" name="action" value="approve">
+                                                        <button type="submit" class="btn btn-success btn-sm">Aprobar</button>
+                                                    </form>
+                                                    <form method="post" action="procesar_solicitud.php" class="d-flex flex-column gap-1">
+                                                        <input type="hidden" name="solicitud_id" value="<?php echo (int) $row['id']; ?>">
+                                                        <input type="hidden" name="action" value="reject">
+                                                        <input type="text" name="comentarios" class="form-control form-control-sm" placeholder="Comentarios (opcional)">
+                                                        <button type="submit" class="btn btn-danger btn-sm">Rechazar</button>
+                                                    </form>
+                                                </div>
+                                            <?php else: ?>
+                                                <span class="text-muted">Sin acciones</span>
+                                            <?php endif; ?>
+                                        </td>
+                                    </tr>
+                                <?php endwhile; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php
+$conn->close();
+include '../Modulos/footer.php';
+?>
+<script>
+    $(document).ready(function () {
+        $('#solicitudesTable').DataTable({
+            language: {
+                lengthMenu: 'Número de filas _MENU_',
+                zeroRecords: 'No se encontraron solicitudes',
+                info: 'Página _PAGE_ de _PAGES_',
+                search: 'Buscar:',
+                paginate: {
+                    first: 'Primero',
+                    last: 'Último',
+                    next: 'Siguiente',
+                    previous: 'Previo'
+                },
+                infoEmpty: 'No hay registros disponibles',
+                infoFiltered: '(Filtrado de _MAX_ registros)'
+            }
+        });
+    });
+</script>

--- a/Modulos/head.php
+++ b/Modulos/head.php
@@ -120,9 +120,15 @@ if ($_SESSION['token'] !== $db_token) {
         <a class="nav-link" href="/Citas/index.php"><i class="fas fa-clipboard"></i>Citas <span class="sr-only"></span></a>
       </li>
       <?php $rol = isset($_SESSION['rol']) ? $_SESSION['rol'] : 0;
-      
+
+      if ($rol == 3 || $rol == 4) {?>
+                   <li class="nav-item ">
+        <a class="nav-link" href="/Citas/solicitudes.php"><i class="fas fa-history"></i>Solicitudes de reprogramación <span class="sr-only"></span></a>
+      </li>
+      <?php }
+
       if ($rol == 3) {?>
-	  	   <li class="nav-item ">
+                   <li class="nav-item ">
         <a class="nav-link" href="/Reportes/index.php"><i class="fas fa-chart-pie"></i>Reportes <span class="sr-only"></span></a>
       </li>
       <li class="nav-item ">

--- a/Usuarios/index.php
+++ b/Usuarios/index.php
@@ -205,7 +205,9 @@ include '../Modulos/footer.php';
 
                 if (rol !== 3) {
                     $('#IdRol option[value="3"]').remove();
+                    $('#IdRol option[value="4"]').remove();
                     $('#editRol option[value="3"]').remove();
+                    $('#editRol option[value="4"]').remove();
                 }
             },
             error: function () {

--- a/cancelar.php
+++ b/cancelar.php
@@ -10,27 +10,49 @@ session_start();
 date_default_timezone_set('America/Mexico_City');
 $fechaActual = date('Y-m-d H:i:s'); // Formato de fecha y hora actual
 
-$idUsuario = $_SESSION['id'];
+$idUsuario = $_SESSION['id'] ?? null;
 
-if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-    $citaId = $_POST['citaId'];
-    $estatus = $_POST['estatus'];
-    $formaPago = $_POST['formaPago'];
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $citaId = isset($_POST['citaId']) ? (int) $_POST['citaId'] : 0;
+    $estatus = isset($_POST['estatus']) ? (int) $_POST['estatus'] : 0;
+    $formaPago = $_POST['formaPago'] ?? null;
 
-    // Actualizar la cita con la nueva fecha programada y la forma de pago
-    $stmt = $conn->prepare("UPDATE Cita SET FormaPago = ?, Estatus = ? WHERE id = ?");
-    $stmt->bind_param('sii', $formaPago, $estatus, $citaId);
+    if ($citaId <= 0 || $estatus <= 0) {
+        header('Location: index.php');
+        exit;
+    }
+
+    if ($formaPago === null || $formaPago === '') {
+        $stmt = $conn->prepare('UPDATE Cita SET FormaPago = NULL, Estatus = ? WHERE id = ?');
+        $stmt->bind_param('ii', $estatus, $citaId);
+    } else {
+        $stmt = $conn->prepare('UPDATE Cita SET FormaPago = ?, Estatus = ? WHERE id = ?');
+        $stmt->bind_param('sii', $formaPago, $estatus, $citaId);
+    }
     $stmt->execute();
     $stmt->close();
 
-    // Insertar en el historial de estatus
-    $stmtInsert = $conn->prepare("INSERT INTO HistorialEstatus(id, fecha, idEstatus, idCita, idUsuario) VALUES (null, ?, 3, ?, ?)");
-    $stmtInsert->bind_param('sii', $fechaActual, $citaId, $idUsuario);
+    $stmtInsert = $conn->prepare('INSERT INTO HistorialEstatus(id, fecha, idEstatus, idCita, idUsuario) VALUES (null, ?, ?, ?, ?)');
+    $stmtInsert->bind_param('siii', $fechaActual, $estatus, $citaId, $idUsuario);
     $stmtInsert->execute();
     $stmtInsert->close();
 
-    echo "Fecha de cita y forma de pago actualizadas correctamente.";
-    header("Location: index.php");
+    if ($estatus === 1) {
+        $tablaSolicitudes = $conn->query("SHOW TABLES LIKE 'SolicitudReprogramacion'");
+        if ($tablaSolicitudes instanceof mysqli_result && $tablaSolicitudes->num_rows > 0) {
+            $tablaSolicitudes->free();
+
+            $comentarioCancelacion = 'Solicitud cerrada automáticamente por cancelación de la cita.';
+            $stmtCancelar = $conn->prepare("UPDATE SolicitudReprogramacion SET estatus = 'rechazada', aprobado_por = ?, fecha_respuesta = ?, comentarios = CASE WHEN comentarios IS NULL OR comentarios = '' THEN ? ELSE CONCAT(comentarios, '\n', ?) END WHERE cita_id = ? AND estatus = 'pendiente'");
+            $stmtCancelar->bind_param('isssi', $idUsuario, $fechaActual, $comentarioCancelacion, $comentarioCancelacion, $citaId);
+            $stmtCancelar->execute();
+            $stmtCancelar->close();
+        } elseif ($tablaSolicitudes instanceof mysqli_result) {
+            $tablaSolicitudes->free();
+        }
+    }
+
+    header('Location: index.php');
     exit;
 }
 

--- a/database/migrations/20241011_000000_create_solicitud_reprogramacion.sql
+++ b/database/migrations/20241011_000000_create_solicitud_reprogramacion.sql
@@ -1,0 +1,24 @@
+-- Crear tabla para las solicitudes de reprogramación generadas por el equipo de ventas
+CREATE TABLE IF NOT EXISTS `SolicitudReprogramacion` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `cita_id` INT NOT NULL,
+  `fecha_anterior` DATETIME NOT NULL,
+  `nueva_fecha` DATETIME NOT NULL,
+  `estatus` ENUM('pendiente','aprobada','rechazada') NOT NULL DEFAULT 'pendiente',
+  `solicitado_por` INT NOT NULL,
+  `comentarios` TEXT NULL,
+  `fecha_solicitud` DATETIME NOT NULL,
+  `aprobado_por` INT DEFAULT NULL,
+  `fecha_respuesta` DATETIME DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_solicitud_estatus` (`estatus`),
+  KEY `idx_solicitud_cita` (`cita_id`),
+  CONSTRAINT `fk_solicitud_cita` FOREIGN KEY (`cita_id`) REFERENCES `Cita` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_solicitud_solicitante` FOREIGN KEY (`solicitado_por`) REFERENCES `Usuarios` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_solicitud_aprobador` FOREIGN KEY (`aprobado_por`) REFERENCES `Usuarios` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Registrar el nuevo rol de Coordinador si no existe
+INSERT INTO `Rol` (`id`, `name`, `activo`)
+VALUES (4, 'Coordinador', 1)
+ON DUPLICATE KEY UPDATE `name` = VALUES(`name`), `activo` = VALUES(`activo`);

--- a/update.php
+++ b/update.php
@@ -10,24 +10,102 @@ session_start();
 date_default_timezone_set('America/Mexico_City');
 $fechaActual = date('Y-m-d H:i:s'); // Formato de fecha y hora actual
 
-$idUsuario = $_SESSION['id'];
+$idUsuario = $_SESSION['id'] ?? null;
+$rolUsuario = $_SESSION['rol'] ?? null;
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-    $citaId = $_POST['citaId'];
-    $fechaProgramada = $_POST['fechaProgramada'];
+    $citaId = isset($_POST['citaId']) ? (int) $_POST['citaId'] : 0;
+    $fechaProgramada = $_POST['fechaProgramada'] ?? '';
 
-    $stmt = $conn->prepare("UPDATE Cita SET Programado = ?, Estatus = 3 WHERE id = ?");
+    if ($citaId <= 0 || empty($fechaProgramada)) {
+        $_SESSION['reprogramacion_mensaje'] = 'La información de la cita es inválida.';
+        $_SESSION['reprogramacion_tipo'] = 'danger';
+        header('Location: index.php');
+        exit;
+    }
+
+    // Constantes de rol
+    $ROL_VENTAS = 1;
+    $ROL_COORDINADOR = 4;
+
+    if ($rolUsuario === $ROL_VENTAS) {
+        $tablaSolicitudes = $conn->query("SHOW TABLES LIKE 'SolicitudReprogramacion'");
+        if (!$tablaSolicitudes || $tablaSolicitudes->num_rows === 0) {
+            if ($tablaSolicitudes instanceof mysqli_result) {
+                $tablaSolicitudes->free();
+            }
+            $_SESSION['reprogramacion_mensaje'] = 'El módulo de solicitudes no está disponible. Contacta al administrador.';
+            $_SESSION['reprogramacion_tipo'] = 'danger';
+            header('Location: index.php');
+            exit;
+        }
+        $tablaSolicitudes->free();
+
+        // Verificar si ya existe una solicitud pendiente para la cita
+        $stmtPendiente = $conn->prepare("SELECT COUNT(*) FROM SolicitudReprogramacion WHERE cita_id = ? AND estatus = 'pendiente'");
+        $stmtPendiente->bind_param('i', $citaId);
+        $stmtPendiente->execute();
+        $stmtPendiente->bind_result($totalPendientes);
+        $stmtPendiente->fetch();
+        $stmtPendiente->close();
+
+        if ($totalPendientes > 0) {
+            $_SESSION['reprogramacion_mensaje'] = 'Ya existe una solicitud pendiente para esta cita.';
+            $_SESSION['reprogramacion_tipo'] = 'warning';
+            header('Location: index.php');
+            exit;
+        }
+
+        // Obtener la fecha programada actual para almacenarla en la solicitud
+        $stmtFechaActual = $conn->prepare('SELECT Programado FROM Cita WHERE id = ?');
+        $stmtFechaActual->bind_param('i', $citaId);
+        $stmtFechaActual->execute();
+        $stmtFechaActual->bind_result($fechaAnterior);
+        $stmtFechaActual->fetch();
+        $stmtFechaActual->close();
+
+        if (!$fechaAnterior) {
+            $_SESSION['reprogramacion_mensaje'] = 'No fue posible localizar la cita seleccionada.';
+            $_SESSION['reprogramacion_tipo'] = 'danger';
+            header('Location: index.php');
+            exit;
+        }
+
+        $stmtSolicitud = $conn->prepare("INSERT INTO SolicitudReprogramacion (cita_id, fecha_anterior, nueva_fecha, estatus, solicitado_por, fecha_solicitud) VALUES (?, ?, ?, 'pendiente', ?, ?)");
+        $stmtSolicitud->bind_param('issis', $citaId, $fechaAnterior, $fechaProgramada, $idUsuario, $fechaActual);
+        $stmtSolicitud->execute();
+        $stmtSolicitud->close();
+
+        $_SESSION['reprogramacion_mensaje'] = 'Se envió la solicitud de reprogramación para aprobación.';
+        $_SESSION['reprogramacion_tipo'] = 'success';
+        header('Location: index.php');
+        exit;
+    }
+
+    // Actualización directa para coordinadores, administradores u otros roles autorizados
+    $stmt = $conn->prepare('UPDATE Cita SET Programado = ?, Estatus = 3 WHERE id = ?');
     $stmt->bind_param('si', $fechaProgramada, $citaId);
     $stmt->execute();
     $stmt->close();
 
-    $stmtInsert = $conn->prepare("INSERT INTO HistorialEstatus(id, fecha, idEstatus, idCita, idUsuario) VALUES (null, ?, 3, ?, ?)");
+    $stmtInsert = $conn->prepare('INSERT INTO HistorialEstatus(id, fecha, idEstatus, idCita, idUsuario) VALUES (null, ?, 3, ?, ?)');
     $stmtInsert->bind_param('sii', $fechaActual, $citaId, $idUsuario);
     $stmtInsert->execute();
     $stmtInsert->close();
 
-    echo "Fecha de cita actualizada correctamente.";
-    header("Location:index.php");
+    // Si la actualización proviene de una solicitud, marcarla como atendida automáticamente
+    if (!empty($_POST['solicitudId']) && $rolUsuario === $ROL_COORDINADOR) {
+        $solicitudId = (int) $_POST['solicitudId'];
+        $stmtAtendida = $conn->prepare("UPDATE SolicitudReprogramacion SET estatus = 'aprobada', aprobado_por = ?, fecha_respuesta = ?, comentarios = IFNULL(comentarios, '') WHERE id = ?");
+        $stmtAtendida->bind_param('isi', $idUsuario, $fechaActual, $solicitudId);
+        $stmtAtendida->execute();
+        $stmtAtendida->close();
+    }
+
+    $_SESSION['reprogramacion_mensaje'] = 'Fecha de cita actualizada correctamente.';
+    $_SESSION['reprogramacion_tipo'] = 'success';
+    header('Location: index.php');
+    exit;
 }
 
 $conn->close();


### PR DESCRIPTION
## Resumen
- agrega el rol de Coordinador a la navegación para acceder al panel de solicitudes
- ajusta la reprogramación de citas para que ventas genere solicitudes pendientes de aprobación
- crea la tabla de solicitudes y una vista para que el coordinador apruebe o rechace los cambios
- cierra automáticamente las solicitudes pendientes cuando la cita se cancela, permitiendo que ventas reagende sin bloqueos

## Pruebas
- php -l index.php
- php -l update.php
- php -l Modulos/head.php
- php -l Usuarios/index.php
- php -l Citas/solicitudes.php
- php -l Citas/procesar_solicitud.php
- php -l cancelar.php

------
https://chatgpt.com/codex/tasks/task_e_68ce23acfe6c832281d4cb8d61e8b38f