### PR TITLE
Require approval for cita cancellations

### DIFF
--- a/Citas/procesar_cancelacion.php
+++ b/Citas/procesar_cancelacion.php
@@ -1,0 +1,132 @@
+<?php
+ini_set('error_reporting', E_ALL);
+ini_set('display_errors', 1);
+
+require_once '../conexion.php';
+session_start();
+
+if (!isset($_SESSION['user']) || !isset($_SESSION['token'])) {
+    header('Location: /login.php');
+    exit;
+}
+
+$rolUsuario = $_SESSION['rol'] ?? 0;
+if (!in_array($rolUsuario, [3, 4], true)) {
+    $_SESSION['solicitud_cancel_mensaje'] = 'No tienes permisos para procesar solicitudes.';
+    $_SESSION['solicitud_cancel_tipo'] = 'danger';
+    header('Location: solicitudes_cancelacion.php');
+    exit;
+}
+
+$conn = conectar();
+
+date_default_timezone_set('America/Mexico_City');
+$fechaActual = date('Y-m-d H:i:s');
+$idUsuario = $_SESSION['id'] ?? null;
+
+$tablaCancelaciones = $conn->query("SHOW TABLES LIKE 'SolicitudCancelacion'");
+if (!($tablaCancelaciones instanceof mysqli_result) || $tablaCancelaciones->num_rows === 0) {
+    if ($tablaCancelaciones instanceof mysqli_result) {
+        $tablaCancelaciones->free();
+    }
+    $_SESSION['solicitud_cancel_mensaje'] = 'El módulo de solicitudes de cancelación no está disponible. Contacta al administrador.';
+    $_SESSION['solicitud_cancel_tipo'] = 'danger';
+    header('Location: solicitudes_cancelacion.php');
+    exit;
+}
+$tablaCancelaciones->free();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    $_SESSION['solicitud_cancel_mensaje'] = 'Solicitud inválida.';
+    $_SESSION['solicitud_cancel_tipo'] = 'danger';
+    header('Location: solicitudes_cancelacion.php');
+    exit;
+}
+
+$solicitudId = isset($_POST['solicitud_id']) ? (int) $_POST['solicitud_id'] : 0;
+$action = $_POST['action'] ?? '';
+$comentarios = trim($_POST['comentarios'] ?? '');
+
+if ($solicitudId <= 0 || !in_array($action, ['approve', 'reject'], true)) {
+    $_SESSION['solicitud_cancel_mensaje'] = 'Parámetros incompletos.';
+    $_SESSION['solicitud_cancel_tipo'] = 'danger';
+    header('Location: solicitudes_cancelacion.php');
+    exit;
+}
+
+$stmtSolicitud = $conn->prepare('SELECT cita_id, estatus FROM SolicitudCancelacion WHERE id = ?');
+$stmtSolicitud->bind_param('i', $solicitudId);
+$stmtSolicitud->execute();
+$stmtSolicitud->bind_result($citaId, $estatusActual);
+
+if (!$stmtSolicitud->fetch()) {
+    $stmtSolicitud->close();
+    $_SESSION['solicitud_cancel_mensaje'] = 'No se encontró la solicitud especificada.';
+    $_SESSION['solicitud_cancel_tipo'] = 'danger';
+    header('Location: solicitudes_cancelacion.php');
+    exit;
+}
+$stmtSolicitud->close();
+
+if ($estatusActual !== 'pendiente') {
+    $_SESSION['solicitud_cancel_mensaje'] = 'La solicitud ya fue atendida.';
+    $_SESSION['solicitud_cancel_tipo'] = 'warning';
+    header('Location: solicitudes_cancelacion.php');
+    exit;
+}
+
+$conn->begin_transaction();
+
+try {
+    if ($action === 'approve') {
+        $stmtUpdate = $conn->prepare('UPDATE Cita SET Estatus = 1 WHERE id = ?');
+        $stmtUpdate->bind_param('i', $citaId);
+        $stmtUpdate->execute();
+        if ($stmtUpdate->errno) {
+            throw new Exception('No fue posible cancelar la cita.');
+        }
+        $stmtUpdate->close();
+
+        $stmtHistorial = $conn->prepare('INSERT INTO HistorialEstatus(id, fecha, idEstatus, idCita, idUsuario) VALUES (null, ?, 1, ?, ?)');
+        $stmtHistorial->bind_param('sii', $fechaActual, $citaId, $idUsuario);
+        $stmtHistorial->execute();
+        if ($stmtHistorial->errno) {
+            throw new Exception('No se pudo registrar el historial de la cita.');
+        }
+        $stmtHistorial->close();
+
+        $comentariosFinal = $comentarios !== '' ? $comentarios : '';
+        $stmtFinalizar = $conn->prepare("UPDATE SolicitudCancelacion SET estatus = 'aprobada', aprobado_por = ?, fecha_respuesta = ?, comentarios = ? WHERE id = ?");
+        $stmtFinalizar->bind_param('issi', $idUsuario, $fechaActual, $comentariosFinal, $solicitudId);
+        $stmtFinalizar->execute();
+        if ($stmtFinalizar->errno) {
+            throw new Exception('No se pudo actualizar la solicitud.');
+        }
+        $stmtFinalizar->close();
+
+        $conn->commit();
+        $_SESSION['solicitud_cancel_mensaje'] = 'Solicitud aprobada y cita cancelada correctamente.';
+        $_SESSION['solicitud_cancel_tipo'] = 'success';
+    } else {
+        $comentariosFinal = $comentarios !== '' ? $comentarios : '';
+        $stmtRechazar = $conn->prepare("UPDATE SolicitudCancelacion SET estatus = 'rechazada', aprobado_por = ?, fecha_respuesta = ?, comentarios = ? WHERE id = ?");
+        $stmtRechazar->bind_param('issi', $idUsuario, $fechaActual, $comentariosFinal, $solicitudId);
+        $stmtRechazar->execute();
+        if ($stmtRechazar->errno) {
+            throw new Exception('No se pudo rechazar la solicitud.');
+        }
+        $stmtRechazar->close();
+
+        $conn->commit();
+        $_SESSION['solicitud_cancel_mensaje'] = 'Solicitud rechazada correctamente.';
+        $_SESSION['solicitud_cancel_tipo'] = 'info';
+    }
+} catch (Exception $exception) {
+    $conn->rollback();
+    $_SESSION['solicitud_cancel_mensaje'] = 'Ocurrió un error al procesar la solicitud: ' . $exception->getMessage();
+    $_SESSION['solicitud_cancel_tipo'] = 'danger';
+}
+
+$conn->close();
+header('Location: solicitudes_cancelacion.php');
+exit;

--- a/Citas/solicitudes_cancelacion.php
+++ b/Citas/solicitudes_cancelacion.php
@@ -1,0 +1,193 @@
+<?php
+include '../Modulos/head.php';
+
+$rolUsuario = $_SESSION['rol'] ?? 0;
+$mensaje = $_SESSION['solicitud_cancel_mensaje'] ?? null;
+$tipoMensaje = $_SESSION['solicitud_cancel_tipo'] ?? 'success';
+unset($_SESSION['solicitud_cancel_mensaje'], $_SESSION['solicitud_cancel_tipo']);
+
+if (!in_array($rolUsuario, [3, 4], true)) {
+    ?>
+    <div class="container mt-4">
+        <div class="alert alert-danger">No tienes permisos para acceder a esta sección.</div>
+    </div>
+    <?php
+    include '../Modulos/footer.php';
+    exit;
+}
+
+$tablaCancelacionesExiste = false;
+if ($resultadoTabla = $conn->query("SHOW TABLES LIKE 'SolicitudCancelacion'")) {
+    $tablaCancelacionesExiste = $resultadoTabla->num_rows > 0;
+    $resultadoTabla->free();
+}
+
+if (!$tablaCancelacionesExiste) {
+    ?>
+    <div class="container mt-4">
+        <div class="alert alert-danger">El módulo de solicitudes de cancelación no está disponible. Contacta al administrador.</div>
+    </div>
+    <?php
+    include '../Modulos/footer.php';
+    exit;
+}
+
+$sql = "SELECT sc.id,
+       sc.cita_id,
+       sc.estatus,
+       sc.fecha_solicitud,
+       sc.fecha_respuesta,
+       sc.comentarios,
+       c.Programado AS fecha_cita,
+       n.name AS paciente,
+       usuP.name AS psicologo,
+       solicitante.name AS solicitante,
+       aprobador.name AS aprobador
+FROM SolicitudCancelacion sc
+INNER JOIN Cita c ON c.id = sc.cita_id
+INNER JOIN nino n ON n.id = c.IdNino
+INNER JOIN Usuarios usuP ON usuP.id = c.IdUsuario
+INNER JOIN Usuarios solicitante ON solicitante.id = sc.solicitado_por
+LEFT JOIN Usuarios aprobador ON aprobador.id = sc.aprobado_por
+ORDER BY sc.fecha_solicitud DESC";
+
+$resultSolicitudes = $conn->query($sql);
+if ($resultSolicitudes === false) {
+    $errorMensaje = $conn->error;
+}
+?>
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title">Solicitudes de cancelación</h4>
+            </div>
+            <div class="card-body">
+                <?php if ($mensaje): ?>
+                    <div class="alert alert-<?php echo htmlspecialchars($tipoMensaje, ENT_QUOTES, 'UTF-8'); ?> alert-dismissible fade show" role="alert">
+                        <?php echo htmlspecialchars($mensaje, ENT_QUOTES, 'UTF-8'); ?>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                <?php endif; ?>
+
+                <?php if (isset($errorMensaje)): ?>
+                    <div class="alert alert-danger" role="alert">
+                        Error al cargar las solicitudes: <?php echo htmlspecialchars($errorMensaje, ENT_QUOTES, 'UTF-8'); ?>
+                    </div>
+                <?php else: ?>
+                    <div class="table-responsive">
+                        <table class="table" id="solicitudesCancelacionTable">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Cita</th>
+                                    <th>Paciente</th>
+                                    <th>Psicólogo</th>
+                                    <th>Fecha de la cita</th>
+                                    <th>Solicitó</th>
+                                    <th>Estatus</th>
+                                    <th>Fecha solicitud</th>
+                                    <th>Respuesta</th>
+                                    <th>Comentarios</th>
+                                    <th>Acciones</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php while ($row = $resultSolicitudes->fetch_assoc()): ?>
+                                    <?php
+                                        $estatus = $row['estatus'];
+                                        $badgeClass = 'bg-secondary';
+                                        $estatusTexto = 'Desconocido';
+                                        switch ($estatus) {
+                                            case 'pendiente':
+                                                $badgeClass = 'bg-warning text-dark';
+                                                $estatusTexto = 'Pendiente';
+                                                break;
+                                            case 'aprobada':
+                                                $badgeClass = 'bg-success';
+                                                $estatusTexto = 'Aprobada';
+                                                break;
+                                            case 'rechazada':
+                                                $badgeClass = 'bg-danger';
+                                                $estatusTexto = 'Rechazada';
+                                                break;
+                                        }
+
+                                        $comentarios = $row['comentarios'] ?? '';
+                                        $comentarios = trim($comentarios) !== '' ? $comentarios : 'Sin comentarios';
+                                        $fechaRespuesta = $row['fecha_respuesta'] ? $row['fecha_respuesta'] : '-';
+                                        $aprobador = $row['aprobador'] ? $row['aprobador'] : '-';
+                                    ?>
+                                    <tr>
+                                        <td><?php echo (int) $row['id']; ?></td>
+                                        <td><?php echo (int) $row['cita_id']; ?></td>
+                                        <td><?php echo htmlspecialchars($row['paciente'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($row['psicologo'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($row['fecha_cita'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($row['solicitante'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><span class="badge <?php echo $badgeClass; ?>"><?php echo $estatusTexto; ?></span></td>
+                                        <td><?php echo htmlspecialchars($row['fecha_solicitud'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td>
+                                            <?php if ($fechaRespuesta !== '-'): ?>
+                                                <?php echo htmlspecialchars($fechaRespuesta, ENT_QUOTES, 'UTF-8'); ?><br>
+                                                <small><?php echo htmlspecialchars($aprobador, ENT_QUOTES, 'UTF-8'); ?></small>
+                                            <?php else: ?>
+                                                -
+                                            <?php endif; ?>
+                                        </td>
+                                        <td><?php echo nl2br(htmlspecialchars($comentarios, ENT_QUOTES, 'UTF-8')); ?></td>
+                                        <td>
+                                            <?php if ($estatus === 'pendiente'): ?>
+                                                <div class="d-flex flex-column gap-2">
+                                                    <form method="post" action="procesar_cancelacion.php" onsubmit="return confirm('¿Deseas aprobar la solicitud de cancelación?');">
+                                                        <input type="hidden" name="solicitud_id" value="<?php echo (int) $row['id']; ?>">
+                                                        <input type="hidden" name="action" value="approve">
+                                                        <button type="submit" class="btn btn-success btn-sm">Aprobar</button>
+                                                    </form>
+                                                    <form method="post" action="procesar_cancelacion.php" class="d-flex flex-column gap-1">
+                                                        <input type="hidden" name="solicitud_id" value="<?php echo (int) $row['id']; ?>">
+                                                        <input type="hidden" name="action" value="reject">
+                                                        <input type="text" name="comentarios" class="form-control form-control-sm" placeholder="Comentarios (opcional)">
+                                                        <button type="submit" class="btn btn-danger btn-sm">Rechazar</button>
+                                                    </form>
+                                                </div>
+                                            <?php else: ?>
+                                                <span class="text-muted">Sin acciones</span>
+                                            <?php endif; ?>
+                                        </td>
+                                    </tr>
+                                <?php endwhile; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php
+$conn->close();
+include '../Modulos/footer.php';
+?>
+<script>
+    $(document).ready(function () {
+        $('#solicitudesCancelacionTable').DataTable({
+            language: {
+                lengthMenu: 'Número de filas _MENU_',
+                zeroRecords: 'No se encontraron solicitudes',
+                info: 'Página _PAGE_ de _PAGES_',
+                search: 'Buscar:',
+                paginate: {
+                    first: 'Primero',
+                    last: 'Último',
+                    next: 'Siguiente',
+                    previous: 'Previo'
+                },
+                infoEmpty: 'No hay registros disponibles',
+                infoFiltered: '(Filtrado de _MAX_ registros)'
+            }
+        });
+    });
+</script>

--- a/Modulos/head.php
+++ b/Modulos/head.php
@@ -125,6 +125,9 @@ if ($_SESSION['token'] !== $db_token) {
                    <li class="nav-item ">
         <a class="nav-link" href="/Citas/solicitudes.php"><i class="fas fa-history"></i>Solicitudes de reprogramación <span class="sr-only"></span></a>
       </li>
+      <li class="nav-item ">
+        <a class="nav-link" href="/Citas/solicitudes_cancelacion.php"><i class="fas fa-ban"></i>Solicitudes de cancelación <span class="sr-only"></span></a>
+      </li>
       <?php }
 
       if ($rol == 3) {?>

--- a/cancelar.php
+++ b/cancelar.php
@@ -11,6 +11,11 @@ date_default_timezone_set('America/Mexico_City');
 $fechaActual = date('Y-m-d H:i:s'); // Formato de fecha y hora actual
 
 $idUsuario = $_SESSION['id'] ?? null;
+$rolUsuario = $_SESSION['rol'] ?? null;
+
+$ROL_VENTAS = 1;
+$ROL_ADMIN = 3;
+$ROL_COORDINADOR = 4;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $citaId = isset($_POST['citaId']) ? (int) $_POST['citaId'] : 0;
@@ -18,6 +23,50 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $formaPago = $_POST['formaPago'] ?? null;
 
     if ($citaId <= 0 || $estatus <= 0) {
+        header('Location: index.php');
+        exit;
+    }
+
+    if ($rolUsuario === $ROL_VENTAS) {
+        $tablaCancelaciones = $conn->query("SHOW TABLES LIKE 'SolicitudCancelacion'");
+        if (!($tablaCancelaciones instanceof mysqli_result) || $tablaCancelaciones->num_rows === 0) {
+            if ($tablaCancelaciones instanceof mysqli_result) {
+                $tablaCancelaciones->free();
+            }
+            $_SESSION['cancelacion_mensaje'] = 'El módulo de solicitudes de cancelación no está disponible. Contacta al administrador.';
+            $_SESSION['cancelacion_tipo'] = 'danger';
+            header('Location: index.php');
+            exit;
+        }
+        $tablaCancelaciones->free();
+
+        $totalPendientes = 0;
+        if ($stmtPendiente = $conn->prepare("SELECT COUNT(*) FROM SolicitudCancelacion WHERE cita_id = ? AND estatus = 'pendiente'")) {
+            $stmtPendiente->bind_param('i', $citaId);
+            $stmtPendiente->execute();
+            $stmtPendiente->bind_result($totalPendientes);
+            $stmtPendiente->fetch();
+            $stmtPendiente->close();
+        }
+
+        if ($totalPendientes > 0) {
+            $_SESSION['cancelacion_mensaje'] = 'Ya existe una solicitud de cancelación pendiente para esta cita.';
+            $_SESSION['cancelacion_tipo'] = 'warning';
+            header('Location: index.php');
+            exit;
+        }
+
+        if ($stmtSolicitud = $conn->prepare("INSERT INTO SolicitudCancelacion (cita_id, estatus, solicitado_por, fecha_solicitud) VALUES (?, 'pendiente', ?, ?)")) {
+            $stmtSolicitud->bind_param('iis', $citaId, $idUsuario, $fechaActual);
+            $stmtSolicitud->execute();
+            $stmtSolicitud->close();
+            $_SESSION['cancelacion_mensaje'] = 'Se envió la solicitud de cancelación para aprobación.';
+            $_SESSION['cancelacion_tipo'] = 'success';
+        } else {
+            $_SESSION['cancelacion_mensaje'] = 'No fue posible registrar la solicitud de cancelación. Intenta nuevamente.';
+            $_SESSION['cancelacion_tipo'] = 'danger';
+        }
+
         header('Location: index.php');
         exit;
     }
@@ -50,7 +99,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } elseif ($tablaSolicitudes instanceof mysqli_result) {
             $tablaSolicitudes->free();
         }
+
+        $tablaSolicitudesCancelacion = $conn->query("SHOW TABLES LIKE 'SolicitudCancelacion'");
+        if ($tablaSolicitudesCancelacion instanceof mysqli_result && $tablaSolicitudesCancelacion->num_rows > 0) {
+            $tablaSolicitudesCancelacion->free();
+
+            $comentarioAprobacion = 'Solicitud de cancelación aprobada automáticamente al cancelar la cita.';
+            if ($stmtCerrarCancelacion = $conn->prepare("UPDATE SolicitudCancelacion SET estatus = 'aprobada', aprobado_por = ?, fecha_respuesta = ?, comentarios = CASE WHEN comentarios IS NULL OR comentarios = '' THEN ? ELSE CONCAT(comentarios, '\n', ?) END WHERE cita_id = ? AND estatus = 'pendiente'")) {
+                $stmtCerrarCancelacion->bind_param('isssi', $idUsuario, $fechaActual, $comentarioAprobacion, $comentarioAprobacion, $citaId);
+                $stmtCerrarCancelacion->execute();
+                $stmtCerrarCancelacion->close();
+            }
+        } elseif ($tablaSolicitudesCancelacion instanceof mysqli_result) {
+            $tablaSolicitudesCancelacion->free();
+        }
     }
+
+    $_SESSION['cancelacion_mensaje'] = 'Cita cancelada correctamente.';
+    $_SESSION['cancelacion_tipo'] = 'success';
 
     header('Location: index.php');
     exit;


### PR DESCRIPTION
## Summary
- add cancellation-specific alerts, table columns, and button states so ventas users submit approval requests instead of cancelling directly
- update the cancel endpoint to create and resolve SolicitudCancelacion records and surface feedback messages
- expose a navigation entry plus dedicated pages for coordinators/administrators to review and approve or reject cancellation requests

## Testing
- php -l index.php
- php -l cancelar.php
- php -l Modulos/head.php
- php -l Citas/solicitudes_cancelacion.php
- php -l Citas/procesar_cancelacion.php

------
https://chatgpt.com/codex/tasks/task_e_68d0346d22f883228e0385cc1a7ab319