### PR TITLE
feat: registrar actividades en logs del sistema

### DIFF
--- a/Citas/procesar_solicitud.php
+++ b/Citas/procesar_solicitud.php
@@ -3,6 +3,7 @@ ini_set('error_reporting', E_ALL);
 ini_set('display_errors', 1);
 
 require_once '../conexion.php';
+require_once __DIR__ . '/../Modulos/logger.php';
 session_start();
 
 if (!isset($_SESSION['user']) || !isset($_SESSION['token'])) {
@@ -94,6 +95,15 @@ try {
             $stmtFinalizar->close();
 
             $conn->commit();
+            registrarLog(
+                $conn,
+                $idUsuario,
+                'citas',
+                'aprobar_solicitud_cancelacion',
+                sprintf('La solicitud #%d de cancelación fue aprobada y la cita #%d se canceló.', $solicitudId, $citaId),
+                'SolicitudReprogramacion',
+                (string) $solicitudId
+            );
             $_SESSION['solicitud_mensaje'] = 'Solicitud de cancelación aprobada y cita cancelada correctamente.';
             $_SESSION['solicitud_tipo'] = 'success';
         } else {
@@ -107,6 +117,15 @@ try {
             $stmtRechazar->close();
 
             $conn->commit();
+            registrarLog(
+                $conn,
+                $idUsuario,
+                'citas',
+                'rechazar_solicitud_cancelacion',
+                sprintf('La solicitud #%d de cancelación fue rechazada para la cita #%d.', $solicitudId, $citaId),
+                'SolicitudReprogramacion',
+                (string) $solicitudId
+            );
             $_SESSION['solicitud_mensaje'] = 'Solicitud de cancelación rechazada correctamente.';
             $_SESSION['solicitud_tipo'] = 'info';
         }
@@ -138,6 +157,15 @@ try {
             $stmtFinalizar->close();
 
             $conn->commit();
+            registrarLog(
+                $conn,
+                $idUsuario,
+                'citas',
+                'aprobar_solicitud_reprogramacion',
+                sprintf('La solicitud #%d de reprogramación fue aprobada y la cita #%d se reprogramó a %s.', $solicitudId, $citaId, $nuevaFecha),
+                'SolicitudReprogramacion',
+                (string) $solicitudId
+            );
             $_SESSION['solicitud_mensaje'] = 'Solicitud aprobada y cita reprogramada correctamente.';
             $_SESSION['solicitud_tipo'] = 'success';
         } else {
@@ -151,6 +179,15 @@ try {
             $stmtRechazar->close();
 
             $conn->commit();
+            registrarLog(
+                $conn,
+                $idUsuario,
+                'citas',
+                'rechazar_solicitud_reprogramacion',
+                sprintf('La solicitud #%d de reprogramación fue rechazada para la cita #%d.', $solicitudId, $citaId),
+                'SolicitudReprogramacion',
+                (string) $solicitudId
+            );
             $_SESSION['solicitud_mensaje'] = 'Solicitud rechazada correctamente.';
             $_SESSION['solicitud_tipo'] = 'info';
         }

--- a/Clientes/agregarNino.php
+++ b/Clientes/agregarNino.php
@@ -1,6 +1,8 @@
 
 <?php
 ini_set('display_errors', 1);
+session_start();
+
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $name = $_POST['name'];
     $id = $_POST['idTutor'];
@@ -9,6 +11,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $Observaciones = $_POST['Observaciones'];
 
     require_once __DIR__ . '/../conexion.php';
+    require_once __DIR__ . '/../Modulos/logger.php';
     $conn = conectar();
     $conn->set_charset("utf8");
     // Preparar y vincular
@@ -17,8 +20,18 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     // Ejecutar la consulta
     if ($stmt->execute()) {
+        $ninoId = $conn->insert_id;
+        registrarLog(
+            $conn,
+            $_SESSION['id'] ?? null,
+            'pacientes',
+            'crear',
+            sprintf('Se agregó el paciente "%s" (ID %d) al tutor #%d.', $name, $ninoId, $id),
+            'Paciente',
+            (string) $ninoId
+        );
         header("Location:index.php");
-		die();
+                die();
     } else {
         echo "Error: " . $stmt->error;
     }

--- a/Clientes/deactivateUser.php
+++ b/Clientes/deactivateUser.php
@@ -1,5 +1,8 @@
 <?php
+session_start();
+
 require_once __DIR__ . '/../conexion.php';
+require_once __DIR__ . '/../Modulos/logger.php';
 $conn = conectar();
 
 if (!isset($_GET['id']) || empty($_GET['id'])) {
@@ -27,6 +30,15 @@ $stmt->bind_param("ii", $nuevoActivo, $id);
 $success = $stmt->execute();
 
 if ($success) {
+    registrarLog(
+        $conn,
+        $_SESSION['id'] ?? null,
+        'clientes',
+        $nuevoActivo === 1 ? 'activar' : 'desactivar',
+        sprintf('Se %s el cliente #%d.', $nuevoActivo === 1 ? 'activó' : 'desactivó', $id),
+        'Cliente',
+        (string) $id
+    );
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['success' => false, 'error' => 'Failed to execute the query']);

--- a/Clientes/editar.php
+++ b/Clientes/editar.php
@@ -1,4 +1,6 @@
 <?php
+session_start();
+
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $id = $_POST['id'];
     $nombre = $_POST['nombre'];
@@ -8,12 +10,22 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $Observaciones = $_POST['Observaciones'];
 
     require_once __DIR__ . '/../conexion.php';
+    require_once __DIR__ . '/../Modulos/logger.php';
     $conn = conectar();
 
     $sql = "UPDATE nino SET name = ?, edad = ?, activo = ?, Observacion = ?, FechaIngreso = ? WHERE id = ?";
     $stmt = $conn->prepare($sql);
     $stmt->bind_param('ssssss', $nombre, $edad, $activo, $Observaciones, $FechaIngreso, $id);
     if ($stmt->execute()) {
+        registrarLog(
+            $conn,
+            $_SESSION['id'] ?? null,
+            'pacientes',
+            'actualizar',
+            sprintf('Se actualizaron los datos del paciente #%s (%s).', $id, $nombre),
+            'Paciente',
+            (string) $id
+        );
         echo "Elemento actualizado correctamente.";
         header("Location:index.php");
         die();

--- a/Clientes/insertcliente.php
+++ b/Clientes/insertcliente.php
@@ -1,11 +1,14 @@
 <?php
 ini_set('display_errors', 1);
+session_start();
+
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $name = $_POST['name'];
     $telefono = $_POST['telefono'];
     $correo = $_POST['correo'];
 
     require_once __DIR__ . '/../conexion.php';
+    require_once __DIR__ . '/../Modulos/logger.php';
     $conn = conectar();
     $conn->set_charset("utf8");
 
@@ -15,8 +18,18 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     // Ejecutar la consulta
     if ($stmt->execute()) {
+        $nuevoClienteId = $conn->insert_id;
+        registrarLog(
+            $conn,
+            $_SESSION['id'] ?? null,
+            'clientes',
+            'crear',
+            sprintf('Se registró el cliente "%s" (ID %d).', $name, $nuevoClienteId),
+            'Cliente',
+            (string) $nuevoClienteId
+        );
         header("Location:index.php");
-		die();
+                die();
     } else {
         echo "Error: " . $stmt->error;
     }

--- a/Clientes/updateUser.php
+++ b/Clientes/updateUser.php
@@ -1,5 +1,8 @@
 <?php
+session_start();
+
 require_once __DIR__ . '/../conexion.php';
+require_once __DIR__ . '/../Modulos/logger.php';
 $conn = conectar();
 
 $id = $_POST['id'];
@@ -10,6 +13,18 @@ $correo = $_POST['correo'];
 $stmt = $conn->prepare("UPDATE `Clientes` SET `name`=?, `telefono`=?, `correo`=? WHERE `id` = ?");
 $stmt->bind_param("sssi", $name, $telefono, $correo, $id);
 $success = $stmt->execute();
+
+if ($success) {
+    registrarLog(
+        $conn,
+        $_SESSION['id'] ?? null,
+        'clientes',
+        'actualizar',
+        sprintf('Se actualizaron los datos del cliente #%d (%s).', $id, $name),
+        'Cliente',
+        (string) $id
+    );
+}
 
 echo json_encode(['success' => $success]);
 

--- a/Logs/index.php
+++ b/Logs/index.php
@@ -1,0 +1,99 @@
+<?php
+include '../Modulos/head.php';
+
+$rolUsuario = $_SESSION['rol'] ?? 0;
+if ($rolUsuario !== 3) {
+    header('Location: /index.php');
+    exit;
+}
+
+$tablaLogsExiste = false;
+if ($resultado = $conn->query("SHOW TABLES LIKE 'LogSistema'")) {
+    $tablaLogsExiste = $resultado->num_rows > 0;
+    $resultado->free();
+}
+
+$registros = [];
+if ($tablaLogsExiste) {
+    $limite = 500;
+    if ($stmtLogs = $conn->prepare('SELECT ls.id, ls.fecha, ls.modulo, ls.accion, ls.descripcion, ls.entidad, ls.referencia, ls.ip, us.name AS usuario_nombre FROM LogSistema ls LEFT JOIN Usuarios us ON us.id = ls.usuario_id ORDER BY ls.fecha DESC LIMIT ?')) {
+        $stmtLogs->bind_param('i', $limite);
+        $stmtLogs->execute();
+        $resultadoLogs = $stmtLogs->get_result();
+        while ($fila = $resultadoLogs->fetch_assoc()) {
+            $registros[] = $fila;
+        }
+        $stmtLogs->close();
+    }
+}
+?>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h4 class="card-title mb-0">Logs del sistema</h4>
+        <span class="text-muted">Mostrando hasta 500 eventos recientes</span>
+      </div>
+      <div class="card-body">
+        <?php if (!$tablaLogsExiste): ?>
+          <div class="alert alert-warning mb-0">
+            La tabla de logs aún no se ha creado. Ejecuta las migraciones para habilitar esta sección.
+          </div>
+        <?php elseif (empty($registros)): ?>
+          <div class="alert alert-info mb-0">
+            No se encontraron eventos registrados.
+          </div>
+        <?php else: ?>
+          <div class="table-responsive">
+            <table id="tablaLogs" class="table table-striped">
+              <thead>
+                <tr>
+                  <th>Fecha</th>
+                  <th>Usuario</th>
+                  <th>Módulo</th>
+                  <th>Acción</th>
+                  <th>Descripción</th>
+                  <th>Entidad</th>
+                  <th>Referencia</th>
+                  <th>IP</th>
+                </tr>
+              </thead>
+              <tbody>
+                <?php foreach ($registros as $registro): ?>
+                  <tr>
+                    <td><?php echo htmlspecialchars($registro['fecha'], ENT_QUOTES, 'UTF-8'); ?></td>
+                    <td><?php echo htmlspecialchars($registro['usuario_nombre'] ?? 'Sin registro', ENT_QUOTES, 'UTF-8'); ?></td>
+                    <td><?php echo htmlspecialchars($registro['modulo'], ENT_QUOTES, 'UTF-8'); ?></td>
+                    <td><?php echo htmlspecialchars($registro['accion'], ENT_QUOTES, 'UTF-8'); ?></td>
+                    <td><?php echo nl2br(htmlspecialchars($registro['descripcion'], ENT_QUOTES, 'UTF-8')); ?></td>
+                    <td><?php echo htmlspecialchars($registro['entidad'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+                    <td><?php echo htmlspecialchars($registro['referencia'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+                    <td><?php echo htmlspecialchars($registro['ip'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+                  </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          </div>
+        <?php endif; ?>
+      </div>
+    </div>
+  </div>
+</div>
+
+<?php include '../Modulos/footer.php'; ?>
+
+<script>
+  $(document).ready(function () {
+    const tabla = $('#tablaLogs');
+    if (tabla.length) {
+      tabla.DataTable({
+        order: [[0, 'desc']],
+        pageLength: 25,
+        language: {
+          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
+        }
+      });
+    }
+  });
+</script>

--- a/Modulos/head.php
+++ b/Modulos/head.php
@@ -136,7 +136,10 @@ if ($_SESSION['token'] !== $db_token) {
       </li>
       <li class="nav-item ">
         <a class="nav-link" href="/Configuracion/index.php"><i class="fas fa-hammer"></i>Configuración <span class="sr-only"></span></a>
-      </li>  
+      </li>
+      <li class="nav-item ">
+        <a class="nav-link" href="/Logs/index.php"><i class="fas fa-clipboard-list"></i>Logs del sistema <span class="sr-only"></span></a>
+      </li>
       <?php } ?>
 
 	 

--- a/Modulos/logger.php
+++ b/Modulos/logger.php
@@ -1,0 +1,67 @@
+<?php
+require_once __DIR__ . '/../conexion.php';
+
+/**
+ * Registra un evento dentro de la tabla de logs del sistema.
+ *
+ * @param mysqli|null $conn Conexión activa a la base de datos. Si es null se abre una nueva.
+ * @param int|null    $usuarioId Identificador del usuario que ejecuta la acción.
+ * @param string      $modulo Módulo donde ocurrió el evento (por ejemplo: citas, usuarios).
+ * @param string      $accion Acción ejecutada (por ejemplo: crear, actualizar, cancelar).
+ * @param string      $descripcion Descripción legible de lo que sucedió.
+ * @param string|null $entidad Nombre de la entidad afectada (por ejemplo: Cita, Usuario).
+ * @param string|null $referencia Identificador de la entidad afectada.
+ *
+ * @return void
+ */
+function registrarLog(?mysqli $conn, ?int $usuarioId, string $modulo, string $accion, string $descripcion, ?string $entidad = null, ?string $referencia = null): void
+{
+    $conexionPropia = false;
+
+    if (!($conn instanceof mysqli)) {
+        $conn = conectar();
+        $conexionPropia = true;
+    }
+
+    if (!($conn instanceof mysqli)) {
+        error_log('registrarLog: no se pudo obtener la conexión a la base de datos.');
+        return;
+    }
+
+    $ip = $_SERVER['REMOTE_ADDR'] ?? null;
+
+    $modulo = mb_substr($modulo, 0, 100, 'UTF-8');
+    $accion = mb_substr($accion, 0, 100, 'UTF-8');
+
+    $query = 'INSERT INTO LogSistema (usuario_id, modulo, accion, descripcion, entidad, referencia, ip) VALUES (?, ?, ?, ?, ?, ?, ?)';
+    $stmt = $conn->prepare($query);
+
+    if ($stmt === false) {
+        error_log('registrarLog: error al preparar la consulta: ' . $conn->error);
+        if ($conexionPropia) {
+            $conn->close();
+        }
+        return;
+    }
+
+    $stmt->bind_param(
+        'issssss',
+        $usuarioId,
+        $modulo,
+        $accion,
+        $descripcion,
+        $entidad,
+        $referencia,
+        $ip
+    );
+
+    if (!$stmt->execute()) {
+        error_log('registrarLog: error al ejecutar la consulta: ' . $stmt->error);
+    }
+
+    $stmt->close();
+
+    if ($conexionPropia) {
+        $conn->close();
+    }
+}

--- a/Usuarios/deactivateUser.php
+++ b/Usuarios/deactivateUser.php
@@ -1,5 +1,8 @@
 <?php
+session_start();
+
 require_once __DIR__ . '/../conexion.php';
+require_once __DIR__ . '/../Modulos/logger.php';
 $conn = conectar();
 
 if (!isset($_GET['id']) || empty($_GET['id'])) {
@@ -23,6 +26,15 @@ if ($user) {
     $success = $stmt->execute();
 
     if ($success) {
+        registrarLog(
+            $conn,
+            $_SESSION['id'] ?? null,
+            'usuarios',
+            $new_activo === 1 ? 'activar' : 'desactivar',
+            sprintf('Se %s el usuario #%d.', $new_activo === 1 ? 'activó' : 'desactivó', $id),
+            'Usuario',
+            (string) $id
+        );
         echo json_encode(['success' => true, 'new_activo' => $new_activo]);
     } else {
         echo json_encode(['success' => false, 'error' => 'Failed to execute the update query']);

--- a/Usuarios/insert_user.php
+++ b/Usuarios/insert_user.php
@@ -1,5 +1,7 @@
 <?php
 ini_set('display_errors', 1);
+session_start();
+
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $name = $_POST['name'];
     $user = $_POST['user'];
@@ -14,16 +16,28 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     }
 
     require_once __DIR__ . '/../conexion.php';
+    require_once __DIR__ . '/../Modulos/logger.php';
     $conn = conectar();
 
     // Preparar y vincular
     $stmt = $conn->prepare("INSERT INTO Usuarios (name, user, pass, token, activo, registro, telefono, correo, IdRol) VALUES (?, ?, ?, '', 1, NOW(), ?, ?, ?)");
+    $token = '';
     $stmt->bind_param("ssssssi", $name, $user, $pass, $token, $telefono, $correo, $IdRol);
 
     // Ejecutar la consulta
     if ($stmt->execute()) {
+        $nuevoUsuarioId = $conn->insert_id;
+        registrarLog(
+            $conn,
+            $_SESSION['id'] ?? null,
+            'usuarios',
+            'crear',
+            sprintf('Se creó el usuario "%s" (ID %d) con rol %s.', $user, $nuevoUsuarioId, $IdRol),
+            'Usuario',
+            (string) $nuevoUsuarioId
+        );
         header("Location: ../usuarios.php");
-		die();
+                die();
     } else {
         echo "Error: " . $stmt->error;
     }

--- a/Usuarios/updateUser.php
+++ b/Usuarios/updateUser.php
@@ -1,5 +1,8 @@
 <?php
+session_start();
+
 require_once __DIR__ . '/../conexion.php';
+require_once __DIR__ . '/../Modulos/logger.php';
 $conn = conectar();
 
 $id = $_POST['id'];
@@ -13,6 +16,18 @@ $IdRol = $_POST['editRol'];
 $stmt = $conn->prepare("UPDATE Usuarios SET name = ?, user = ?, pass = ?, telefono = ?, correo = ?, IdRol = ? WHERE id = ?");
 $stmt->bind_param("sssssii", $name, $user, $pass, $telefono, $correo, $IdRol, $id);
 $success = $stmt->execute();
+
+if ($success) {
+    registrarLog(
+        $conn,
+        $_SESSION['id'] ?? null,
+        'usuarios',
+        'actualizar',
+        sprintf('Se actualizaron los datos del usuario #%d (%s).', $id, $user),
+        'Usuario',
+        (string) $id
+    );
+}
 
 echo json_encode(['success' => $success]);
 

--- a/database/migrations/20241015_000002_create_log_sistema_table.sql
+++ b/database/migrations/20241015_000002_create_log_sistema_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS `LogSistema` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `fecha` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `usuario_id` INT NULL,
+  `modulo` VARCHAR(100) NOT NULL,
+  `accion` VARCHAR(100) NOT NULL,
+  `descripcion` TEXT NOT NULL,
+  `entidad` VARCHAR(100) DEFAULT NULL,
+  `referencia` VARCHAR(100) DEFAULT NULL,
+  `ip` VARCHAR(45) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_logs_fecha` (`fecha`),
+  KEY `idx_logs_modulo` (`modulo`),
+  KEY `idx_logs_usuario` (`usuario_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/procesar_cita.php
+++ b/procesar_cita.php
@@ -14,6 +14,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     }
 
     require_once 'conexion.php';
+    require_once __DIR__ . '/Modulos/logger.php';
     $conn = conectar();
     $conn->set_charset('utf8');
 
@@ -44,7 +45,24 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $stmt = $conn->prepare($sql);
     $stmt->bind_param('iiisdsis', $idCliente, $idPsicologo, $idGenerado, $fechaActual, $costo, $fechaCita, $estatus, $tipo);
     $stmt->execute();
+    $nuevaCitaId = $conn->insert_id;
     $stmt->close();
+
+    registrarLog(
+        $conn,
+        $idGenerado,
+        'citas',
+        'crear',
+        sprintf(
+            'Se creó la cita #%d para el paciente %d con el psicólogo %d programada el %s.',
+            $nuevaCitaId,
+            $idCliente,
+            $idPsicologo,
+            $fechaCita
+        ),
+        'Cita',
+        (string) $nuevaCitaId
+    );
 
     echo json_encode(['success' => true]);
     $conn->close();


### PR DESCRIPTION
## Summary
- crear la tabla `LogSistema` y un helper reutilizable para registrar eventos del sistema
- instrumentar la creación, actualización y cancelación de citas, así como las operaciones de usuarios y clientes, para almacenar logs detallados
- añadir una vista administrativa y acceso en el menú para revisar los registros recientes

## Testing
- php -l (archivos PHP modificados)


------
https://chatgpt.com/codex/tasks/task_e_68d077069dc08322bdcbda72e0904b71