### PR TITLE
Allow all roles to register payments

### DIFF
--- a/cancelar.php
+++ b/cancelar.php
@@ -44,7 +44,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit;
     }
 
-    if ($rolUsuario === $ROL_VENTAS) {
+    if ($rolUsuario === $ROL_VENTAS && $estatus === 1) {
         $tablaSolicitudes = $conn->query("SHOW TABLES LIKE 'SolicitudReprogramacion'");
         if (!($tablaSolicitudes instanceof mysqli_result) || $tablaSolicitudes->num_rows === 0) {
             if ($tablaSolicitudes instanceof mysqli_result) {
@@ -175,8 +175,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 
-    $_SESSION['cancelacion_mensaje'] = 'Cita cancelada correctamente.';
-    $_SESSION['cancelacion_tipo'] = 'success';
+    if ($estatus === 1) {
+        $_SESSION['cancelacion_mensaje'] = 'Cita cancelada correctamente.';
+        $_SESSION['cancelacion_tipo'] = 'success';
+    } elseif ($estatus === 4) {
+        $_SESSION['cancelacion_mensaje'] = 'Pago registrado correctamente.';
+        $_SESSION['cancelacion_tipo'] = 'success';
+    } else {
+        $_SESSION['cancelacion_mensaje'] = 'Estatus de la cita actualizado correctamente.';
+        $_SESSION['cancelacion_tipo'] = 'success';
+    }
 
     header('Location: index.php');
     exit;


### PR DESCRIPTION
## Summary
- ensure the sales role only creates cancellation requests when cancelling appointments
- show tailored confirmation messages when cancelling, registering a payment, or performing other updates

## Testing
- php -l app/cancelar.php

------
https://chatgpt.com/codex/tasks/task_e_68d1c801ff948322833fe794cf6c3a8d