### PR TITLE
Add payment breakdown table for cita payments

### DIFF
--- a/Clientes/agregarNino.php
+++ b/Clientes/agregarNino.php
@@ -15,7 +15,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $conn = conectar();
     $conn->set_charset("utf8");
     // Preparar y vincular
-    $stmt = $conn->prepare("INSERT INTO `nino`(`id`, `name`, `activo`, `edad`, `Observacion`, `FechaIngreso`, `idtutor`) VALUES (null,?,1,?,?,?,?)");
+    $stmt = $conn->prepare("INSERT INTO `nino`(`id`, `name`, `activo`, `edad`, `Observacion`, `FechaIngreso`, `idtutor`, `saldo_paquete`) VALUES (null, ?, 1, ?, ?, ?, ?, 0)");
     $stmt->bind_param("sissi", $name,  $edad, $Observaciones, $FechaIngreso, $id);
 
     // Ejecutar la consulta

--- a/Modulos/saldo_pacientes.php
+++ b/Modulos/saldo_pacientes.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Funciones auxiliares para administrar el saldo de los pacientes.
+ */
+
+if (!function_exists('obtenerSaldoPaciente')) {
+    /**
+     * Obtiene el saldo actual registrado para un paciente.
+     */
+    function obtenerSaldoPaciente(mysqli $conn, int $pacienteId): float
+    {
+        $saldo = 0.0;
+        $stmt = $conn->prepare('SELECT saldo_paquete FROM nino WHERE id = ?');
+        if ($stmt) {
+            $stmt->bind_param('i', $pacienteId);
+            if ($stmt->execute()) {
+                $stmt->bind_result($saldoObtenido);
+                if ($stmt->fetch()) {
+                    $saldo = (float) $saldoObtenido;
+                }
+            }
+            $stmt->close();
+        }
+
+        return $saldo;
+    }
+}
+
+if (!function_exists('ajustarSaldoPaciente')) {
+    /**
+     * Ajusta el saldo del paciente sumando o restando el valor indicado.
+     */
+    function ajustarSaldoPaciente(mysqli $conn, int $pacienteId, float $ajuste): bool
+    {
+        $stmt = $conn->prepare('UPDATE nino SET saldo_paquete = saldo_paquete + ? WHERE id = ?');
+        if (!$stmt) {
+            return false;
+        }
+
+        $stmt->bind_param('di', $ajuste, $pacienteId);
+        $resultado = $stmt->execute();
+        $stmt->close();
+
+        return $resultado;
+    }
+}

--- a/cancelar.php
+++ b/cancelar.php
@@ -5,6 +5,7 @@ ini_set('display_errors', 1);
 
 require_once 'conexion.php';
 require_once __DIR__ . '/Modulos/logger.php';
+require_once __DIR__ . '/Modulos/saldo_pacientes.php';
 $conn = conectar();
 session_start();
 
@@ -21,7 +22,25 @@ $ROL_COORDINADOR = 4;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $citaId = isset($_POST['citaId']) ? (int) $_POST['citaId'] : 0;
     $estatus = isset($_POST['estatus']) ? (int) $_POST['estatus'] : 0;
-    $formaPago = $_POST['formaPago'] ?? null;
+    $formaPago = isset($_POST['formaPago']) ? trim((string) $_POST['formaPago']) : null;
+    $pagosRegistrados = [];
+    if (isset($_POST['pagos'])) {
+        $pagosDecodificados = json_decode((string) $_POST['pagos'], true);
+        if (json_last_error() === JSON_ERROR_NONE && is_array($pagosDecodificados)) {
+            foreach ($pagosDecodificados as $pagoDetalle) {
+                $metodo = isset($pagoDetalle['metodo']) ? trim((string) $pagoDetalle['metodo']) : '';
+                $monto = isset($pagoDetalle['monto']) ? (float) $pagoDetalle['monto'] : 0.0;
+                if ($metodo !== '' && $monto > 0) {
+                    $pagosRegistrados[] = [
+                        'metodo' => substr($metodo, 0, 50),
+                        'monto' => $monto
+                    ];
+                }
+            }
+        }
+    }
+    $usarSaldo = isset($_POST['usarSaldo']) ? ((int) $_POST['usarSaldo'] === 1) : false;
+    $montoPago = isset($_POST['montoPago']) ? (float) $_POST['montoPago'] : 0.0;
 
     if ($citaId <= 0 || $estatus <= 0) {
         header('Location: index.php');
@@ -29,10 +48,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     $fechaProgramadaActual = null;
-    if ($stmtDatosCita = $conn->prepare('SELECT Programado FROM Cita WHERE id = ?')) {
+    $pacienteId = null;
+    $costoCita = 0.0;
+    if ($stmtDatosCita = $conn->prepare('SELECT Programado, IdNino, costo FROM Cita WHERE id = ?')) {
         $stmtDatosCita->bind_param('i', $citaId);
         $stmtDatosCita->execute();
-        $stmtDatosCita->bind_result($fechaProgramadaActual);
+        $stmtDatosCita->bind_result($fechaProgramadaActual, $pacienteId, $costoCita);
         $stmtDatosCita->fetch();
         $stmtDatosCita->close();
     }
@@ -99,20 +120,171 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit;
     }
 
-    if ($formaPago === null || $formaPago === '') {
-        $stmt = $conn->prepare('UPDATE Cita SET FormaPago = NULL, Estatus = ? WHERE id = ?');
-        $stmt->bind_param('ii', $estatus, $citaId);
-    } else {
-        $stmt = $conn->prepare('UPDATE Cita SET FormaPago = ?, Estatus = ? WHERE id = ?');
-        $stmt->bind_param('sii', $formaPago, $estatus, $citaId);
-    }
-    $stmt->execute();
-    $stmt->close();
+    $usaTransaccion = false;
+    $detallesSaldo = [];
+    $detallesPagos = [];
 
-    $stmtInsert = $conn->prepare('INSERT INTO HistorialEstatus(id, fecha, idEstatus, idCita, idUsuario) VALUES (null, ?, ?, ?, ?)');
-    $stmtInsert->bind_param('siii', $fechaActual, $estatus, $citaId, $idUsuario);
-    $stmtInsert->execute();
-    $stmtInsert->close();
+    if ($estatus === 4) {
+        $usaTransaccion = true;
+        $conn->begin_transaction();
+    }
+
+    try {
+        if ($estatus === 4) {
+            if (!$pacienteId) {
+                throw new Exception('No fue posible identificar al paciente de la cita.');
+            }
+
+            $pagosProcesados = $pagosRegistrados;
+
+            if (empty($pagosProcesados) && $usarSaldo) {
+                $pagosProcesados[] = [
+                    'metodo' => 'Saldo',
+                    'monto' => (float) $costoCita
+                ];
+            }
+
+            if (empty($pagosProcesados) && $formaPago !== null && $formaPago !== '' && $montoPago > 0) {
+                $pagosProcesados[] = [
+                    'metodo' => $formaPago,
+                    'monto' => $montoPago
+                ];
+            }
+
+            if (empty($pagosProcesados)) {
+                throw new Exception('Registra al menos una forma de pago válida.');
+            }
+
+            $totalPagos = 0.0;
+            $totalSaldoUtilizado = 0.0;
+            $totalPagosExternos = 0.0;
+            $metodosResumen = [];
+            $pagosValidados = [];
+
+            foreach ($pagosProcesados as $pagoDetalle) {
+                $metodo = isset($pagoDetalle['metodo']) ? trim((string) $pagoDetalle['metodo']) : '';
+                $monto = isset($pagoDetalle['monto']) ? (float) $pagoDetalle['monto'] : 0.0;
+
+                if ($metodo === '' || $monto <= 0) {
+                    throw new Exception('Cada forma de pago debe incluir un método y un monto mayor a cero.');
+                }
+
+                if (strlen($metodo) > 50) {
+                    $metodo = substr($metodo, 0, 50);
+                }
+
+                $totalPagos += $monto;
+                if (strcasecmp($metodo, 'Saldo') === 0) {
+                    $totalSaldoUtilizado += $monto;
+                } else {
+                    $totalPagosExternos += $monto;
+                }
+
+                $metodosResumen[] = $metodo;
+                $pagosValidados[] = [
+                    'metodo' => $metodo,
+                    'monto' => $monto
+                ];
+            }
+
+            if ($totalPagos + 0.0001 < (float) $costoCita) {
+                throw new Exception('El monto total registrado es menor al costo de la cita.');
+            }
+
+            $saldoDisponible = obtenerSaldoPaciente($conn, (int) $pacienteId);
+            if ($totalSaldoUtilizado > 0) {
+                if ($saldoDisponible + 0.0001 < $totalSaldoUtilizado) {
+                    throw new Exception('El saldo del paciente es insuficiente para cubrir los montos asignados.');
+                }
+                if (!ajustarSaldoPaciente($conn, (int) $pacienteId, -1 * $totalSaldoUtilizado)) {
+                    throw new Exception('No fue posible actualizar el saldo del paciente.');
+                }
+                $detallesSaldo[] = sprintf('Se descontaron %s del saldo del paciente.', number_format($totalSaldoUtilizado, 2));
+            }
+
+            $montoNecesarioExternos = max(0, (float) $costoCita - $totalSaldoUtilizado);
+            $excedente = max(0, $totalPagosExternos - $montoNecesarioExternos);
+            if ($excedente > 0) {
+                if (!ajustarSaldoPaciente($conn, (int) $pacienteId, $excedente)) {
+                    throw new Exception('No fue posible almacenar el saldo restante del paciente.');
+                }
+                $detallesSaldo[] = sprintf('Se agregaron %s al saldo del paciente.', number_format($excedente, 2));
+            }
+
+            $stmtEliminarPagos = $conn->prepare('DELETE FROM CitaPagos WHERE cita_id = ?');
+            if (!$stmtEliminarPagos) {
+                throw new Exception('No fue posible preparar la limpieza de los pagos registrados previamente.');
+            }
+            $stmtEliminarPagos->bind_param('i', $citaId);
+            $stmtEliminarPagos->execute();
+            $stmtEliminarPagos->close();
+
+            $insertQuery = $idUsuario !== null
+                ? 'INSERT INTO CitaPagos (cita_id, metodo, monto, registrado_por) VALUES (?, ?, ?, ?)'
+                : 'INSERT INTO CitaPagos (cita_id, metodo, monto, registrado_por) VALUES (?, ?, ?, NULL)';
+            $stmtInsertPago = $conn->prepare($insertQuery);
+            if (!$stmtInsertPago) {
+                throw new Exception('No fue posible guardar el detalle de los pagos.');
+            }
+
+            foreach ($pagosValidados as $pagoValidado) {
+                $metodo = $pagoValidado['metodo'];
+                $monto = $pagoValidado['monto'];
+
+                if ($idUsuario !== null) {
+                    $stmtInsertPago->bind_param('isdi', $citaId, $metodo, $monto, $idUsuario);
+                } else {
+                    $stmtInsertPago->bind_param('isd', $citaId, $metodo, $monto);
+                }
+
+                if (!$stmtInsertPago->execute()) {
+                    $stmtInsertPago->close();
+                    throw new Exception('No fue posible guardar el detalle de los pagos.');
+                }
+            }
+
+            $stmtInsertPago->close();
+
+            $metodosUnicos = array_values(array_unique($metodosResumen));
+            if (count($metodosUnicos) === 1) {
+                $formaPago = $metodosUnicos[0];
+            } elseif (!empty($metodosUnicos)) {
+                $resumenMixto = 'Mixto (' . implode(', ', $metodosUnicos) . ')';
+                $formaPago = substr($resumenMixto, 0, 50);
+            }
+
+            foreach ($pagosValidados as $pagoValidado) {
+                $detallesPagos[] = sprintf('%s $%s', $pagoValidado['metodo'], number_format($pagoValidado['monto'], 2));
+            }
+        }
+
+        if ($formaPago === null || $formaPago === '') {
+            $stmt = $conn->prepare('UPDATE Cita SET FormaPago = NULL, Estatus = ? WHERE id = ?');
+            $stmt->bind_param('ii', $estatus, $citaId);
+        } else {
+            $stmt = $conn->prepare('UPDATE Cita SET FormaPago = ?, Estatus = ? WHERE id = ?');
+            $stmt->bind_param('sii', $formaPago, $estatus, $citaId);
+        }
+        $stmt->execute();
+        $stmt->close();
+
+        $stmtInsert = $conn->prepare('INSERT INTO HistorialEstatus(id, fecha, idEstatus, idCita, idUsuario) VALUES (null, ?, ?, ?, ?)');
+        $stmtInsert->bind_param('siii', $fechaActual, $estatus, $citaId, $idUsuario);
+        $stmtInsert->execute();
+        $stmtInsert->close();
+
+        if ($usaTransaccion) {
+            $conn->commit();
+        }
+    } catch (Exception $e) {
+        if ($usaTransaccion) {
+            $conn->rollback();
+        }
+        $_SESSION['cancelacion_mensaje'] = $e->getMessage();
+        $_SESSION['cancelacion_tipo'] = 'danger';
+        header('Location: index.php');
+        exit;
+    }
 
     $accionLog = 'actualizar_estatus';
     $descripcionLog = sprintf('La cita #%d cambió su estatus a %d.', $citaId, $estatus);
@@ -127,6 +299,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if ($formaPago !== null && $formaPago !== '') {
         $descripcionLog .= sprintf(' Forma de pago: %s.', $formaPago);
+    }
+
+    if (!empty($detallesPagos)) {
+        $descripcionLog .= ' Pagos registrados: ' . implode('; ', $detallesPagos) . '.';
+    }
+
+    if (!empty($detallesSaldo)) {
+        $descripcionLog .= ' ' . implode(' ', $detallesSaldo);
     }
 
     registrarLog(
@@ -179,7 +359,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['cancelacion_mensaje'] = 'Cita cancelada correctamente.';
         $_SESSION['cancelacion_tipo'] = 'success';
     } elseif ($estatus === 4) {
-        $_SESSION['cancelacion_mensaje'] = 'Pago registrado correctamente.';
+        $mensajePago = 'Pago registrado correctamente.';
+        if (!empty($detallesPagos)) {
+            $mensajePago .= ' Pagos: ' . implode('; ', $detallesPagos) . '.';
+        }
+        if (!empty($detallesSaldo)) {
+            $mensajePago .= ' ' . implode(' ', $detallesSaldo);
+        }
+        $_SESSION['cancelacion_mensaje'] = $mensajePago;
         $_SESSION['cancelacion_tipo'] = 'success';
     } else {
         $_SESSION['cancelacion_mensaje'] = 'Estatus de la cita actualizado correctamente.';

--- a/database/migrations/20241018_000000_add_saldo_paquete_to_nino.sql
+++ b/database/migrations/20241018_000000_add_saldo_paquete_to_nino.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `nino`
+    ADD COLUMN `saldo_paquete` DECIMAL(10,2) NOT NULL DEFAULT 0 AFTER `idtutor`;

--- a/database/migrations/20241018_000001_create_cita_pagos_table.sql
+++ b/database/migrations/20241018_000001_create_cita_pagos_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `CitaPagos` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `cita_id` INT NOT NULL,
+    `metodo` VARCHAR(50) NOT NULL,
+    `monto` DECIMAL(10,2) NOT NULL,
+    `registrado_por` INT NULL,
+    `creado_en` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    KEY `idx_cita_pagos_cita_id` (`cita_id`),
+    CONSTRAINT `fk_cita_pagos_cita`
+        FOREIGN KEY (`cita_id`) REFERENCES `Cita` (`id`)
+        ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- add a payment breakdown table in the cita pago modal so multiple methods and saldo can be combined per pago
- update cancelar.php to validate multi-método pagos, ajustar saldo y registrar cada partida en la nueva tabla historial
- crear la migración `CitaPagos` para guardar el detalle de montos y métodos por cita

## Testing
- php -l cancelar.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68d81f2f63648322afdaef577bc02981