### PR TITLE
Add package management and automate package payments

### DIFF
--- a/Configuracion/guardar_paquete.php
+++ b/Configuracion/guardar_paquete.php
@@ -1,0 +1,58 @@
+<?php
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: paquetes.php');
+    exit;
+}
+
+$nombre = isset($_POST['nombre']) ? trim($_POST['nombre']) : '';
+$primerPago = isset($_POST['primer_pago']) ? (float) $_POST['primer_pago'] : null;
+$saldoAdicional = isset($_POST['saldo_adicional']) ? (float) $_POST['saldo_adicional'] : null;
+
+if ($nombre === '' || $primerPago === null || $saldoAdicional === null || $primerPago < 0 || $saldoAdicional < 0) {
+    $_SESSION['paquetes_mensaje'] = 'Proporciona un nombre y montos válidos para crear el paquete.';
+    $_SESSION['paquetes_tipo'] = 'danger';
+    header('Location: paquetes.php');
+    exit;
+}
+
+require_once __DIR__ . '/../conexion.php';
+require_once __DIR__ . '/../Modulos/logger.php';
+
+$conn = conectar();
+$conn->set_charset('utf8');
+
+$stmt = $conn->prepare('INSERT INTO Paquetes (nombre, primer_pago_monto, saldo_adicional, activo) VALUES (?, ?, ?, 1)');
+if ($stmt === false) {
+    $_SESSION['paquetes_mensaje'] = 'No fue posible preparar el registro del paquete.';
+    $_SESSION['paquetes_tipo'] = 'danger';
+    header('Location: paquetes.php');
+    exit;
+}
+
+$stmt->bind_param('sdd', $nombre, $primerPago, $saldoAdicional);
+
+if ($stmt->execute()) {
+    $_SESSION['paquetes_mensaje'] = 'Paquete creado correctamente.';
+    $_SESSION['paquetes_tipo'] = 'success';
+
+    registrarLog(
+        $conn,
+        $_SESSION['id'] ?? null,
+        'paquetes',
+        'crear',
+        sprintf('Se creó el paquete "%s" con primer pago de %.2f y saldo adicional de %.2f.', $nombre, $primerPago, $saldoAdicional),
+        'Paquete',
+        (string) $conn->insert_id
+    );
+} else {
+    $_SESSION['paquetes_mensaje'] = 'Ocurrió un error al guardar el paquete: ' . $stmt->error;
+    $_SESSION['paquetes_tipo'] = 'danger';
+}
+
+$stmt->close();
+$conn->close();
+
+header('Location: paquetes.php');
+exit;

--- a/Configuracion/paquetes.php
+++ b/Configuracion/paquetes.php
@@ -1,0 +1,129 @@
+<?php
+include '../Modulos/head.php';
+
+$mensajePaquetes = $_SESSION['paquetes_mensaje'] ?? null;
+$tipoMensajePaquetes = $_SESSION['paquetes_tipo'] ?? 'success';
+unset($_SESSION['paquetes_mensaje'], $_SESSION['paquetes_tipo']);
+
+$paquetes = [];
+$consultaPaquetes = $conn->query('SELECT id, nombre, primer_pago_monto, saldo_adicional, activo, creado_en FROM Paquetes ORDER BY nombre');
+if ($consultaPaquetes instanceof mysqli_result) {
+    while ($fila = $consultaPaquetes->fetch_assoc()) {
+        $paquetes[] = $fila;
+    }
+    $consultaPaquetes->free();
+}
+?>
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h4 class="card-title mb-0">Paquetes</h4>
+                <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#insertPaqueteModal">
+                    Agregar
+                </button>
+            </div>
+            <div class="card-body">
+                <?php if ($mensajePaquetes): ?>
+                    <div class="alert alert-<?php echo htmlspecialchars($tipoMensajePaquetes, ENT_QUOTES, 'UTF-8'); ?> alert-dismissible fade show" role="alert">
+                        <?php echo htmlspecialchars($mensajePaquetes, ENT_QUOTES, 'UTF-8'); ?>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                <?php endif; ?>
+                <div class="table-responsive">
+                    <?php if (!empty($paquetes)) : ?>
+                        <table class="table" id="tablaPaquetes">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Nombre</th>
+                                    <th>Primer pago</th>
+                                    <th>Saldo adicional</th>
+                                    <th>Activo</th>
+                                    <th>Creado</th>
+                                    <th>Acciones</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($paquetes as $paquete) : ?>
+                                    <tr>
+                                        <td><?php echo (int) $paquete['id']; ?></td>
+                                        <td><?php echo htmlspecialchars($paquete['nombre'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td>$<?php echo number_format((float) $paquete['primer_pago_monto'], 2); ?></td>
+                                        <td>$<?php echo number_format((float) $paquete['saldo_adicional'], 2); ?></td>
+                                        <td><?php echo ((int) $paquete['activo'] === 1) ? 'Sí' : 'No'; ?></td>
+                                        <td><?php echo htmlspecialchars($paquete['creado_en'], ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td>
+                                            <form action="toggle_paquete.php" method="post" class="d-inline">
+                                                <input type="hidden" name="id" value="<?php echo (int) $paquete['id']; ?>">
+                                                <input type="hidden" name="activo" value="<?php echo (int) $paquete['activo']; ?>">
+                                                <button type="submit" class="btn btn-sm btn-outline-primary">
+                                                    <?php echo ((int) $paquete['activo'] === 1) ? 'Desactivar' : 'Activar'; ?>
+                                                </button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    <?php else : ?>
+                        <p class="mb-0">Aún no hay paquetes registrados.</p>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="insertPaqueteModal" tabindex="-1" aria-labelledby="insertPaqueteModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="insertPaqueteModalLabel">Crear paquete</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="insertPaqueteForm" action="guardar_paquete.php" method="post">
+                    <div class="mb-3">
+                        <label for="paqueteNombre" class="form-label">Nombre</label>
+                        <input type="text" class="form-control" id="paqueteNombre" name="nombre" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="paquetePrimerPago" class="form-label">Monto del primer pago</label>
+                        <input type="number" class="form-control" id="paquetePrimerPago" name="primer_pago" min="0" step="0.01" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="paqueteSaldo" class="form-label">Saldo adicional otorgado</label>
+                        <input type="number" class="form-control" id="paqueteSaldo" name="saldo_adicional" min="0" step="0.01" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Guardar</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<?php $conn->close(); ?>
+<?php include '../Modulos/footer.php'; ?>
+<script>
+    $(document).ready(function () {
+        if ($('#tablaPaquetes').length) {
+            $('#tablaPaquetes').DataTable({
+                language: {
+                    lengthMenu: 'Número de filas _MENU_',
+                    zeroRecords: 'No encontró nada, usa los filtros para pulir la búsqueda',
+                    info: 'Página _PAGE_ de _PAGES_',
+                    search: 'Buscar:',
+                    paginate: {
+                        first: 'Primero',
+                        last: 'Último',
+                        next: 'Siguiente',
+                        previous: 'Previo'
+                    },
+                    infoEmpty: 'No hay registros disponibles',
+                    infoFiltered: '(Buscamos en _MAX_ resultados)',
+                },
+            });
+        }
+    });
+</script>

--- a/Configuracion/toggle_paquete.php
+++ b/Configuracion/toggle_paquete.php
@@ -1,0 +1,58 @@
+<?php
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: paquetes.php');
+    exit;
+}
+
+$id = isset($_POST['id']) ? (int) $_POST['id'] : 0;
+$activoActual = isset($_POST['activo']) ? (int) $_POST['activo'] : 0;
+
+if ($id <= 0) {
+    $_SESSION['paquetes_mensaje'] = 'Identificador de paquete inválido.';
+    $_SESSION['paquetes_tipo'] = 'danger';
+    header('Location: paquetes.php');
+    exit;
+}
+
+require_once __DIR__ . '/../conexion.php';
+require_once __DIR__ . '/../Modulos/logger.php';
+
+$conn = conectar();
+$conn->set_charset('utf8');
+
+$nuevoEstado = $activoActual === 1 ? 0 : 1;
+$stmt = $conn->prepare('UPDATE Paquetes SET activo = ? WHERE id = ?');
+if ($stmt === false) {
+    $_SESSION['paquetes_mensaje'] = 'No fue posible preparar el cambio de estado.';
+    $_SESSION['paquetes_tipo'] = 'danger';
+    header('Location: paquetes.php');
+    exit;
+}
+
+$stmt->bind_param('ii', $nuevoEstado, $id);
+
+if ($stmt->execute()) {
+    $_SESSION['paquetes_mensaje'] = $nuevoEstado === 1 ? 'Paquete activado correctamente.' : 'Paquete desactivado correctamente.';
+    $_SESSION['paquetes_tipo'] = 'success';
+
+    registrarLog(
+        $conn,
+        $_SESSION['id'] ?? null,
+        'paquetes',
+        'actualizar',
+        sprintf('El paquete #%d cambió su estado a %s.', $id, $nuevoEstado === 1 ? 'activo' : 'inactivo'),
+        'Paquete',
+        (string) $id
+    );
+} else {
+    $_SESSION['paquetes_mensaje'] = 'No fue posible actualizar el paquete: ' . $stmt->error;
+    $_SESSION['paquetes_tipo'] = 'danger';
+}
+
+$stmt->close();
+$conn->close();
+
+header('Location: paquetes.php');
+exit;

--- a/Modulos/getPaquetes.php
+++ b/Modulos/getPaquetes.php
@@ -1,0 +1,28 @@
+<?php
+ini_set('error_reporting', E_ALL);
+ini_set('display_errors', 1);
+
+header('Content-Type: application/json; charset=utf-8');
+
+require_once __DIR__ . '/../conexion.php';
+
+$conn = conectar();
+$conn->set_charset('utf8');
+
+$paquetes = [];
+$sql = "SELECT id, nombre, primer_pago_monto, saldo_adicional FROM Paquetes WHERE activo = 1 ORDER BY nombre";
+if ($resultado = $conn->query($sql)) {
+    while ($fila = $resultado->fetch_assoc()) {
+        $paquetes[] = [
+            'id' => (int) $fila['id'],
+            'nombre' => $fila['nombre'],
+            'primer_pago_monto' => (float) $fila['primer_pago_monto'],
+            'saldo_adicional' => (float) $fila['saldo_adicional'],
+        ];
+    }
+    $resultado->free();
+}
+
+$conn->close();
+
+echo json_encode($paquetes, JSON_UNESCAPED_UNICODE);

--- a/Modulos/head.php
+++ b/Modulos/head.php
@@ -141,6 +141,9 @@ if ($_SESSION['token'] !== $db_token) {
         <a class="nav-link" href="/Configuracion/index.php"><i class="fas fa-hammer"></i>Configuración <span class="sr-only"></span></a>
       </li>
       <li class="nav-item ">
+        <a class="nav-link" href="/Configuracion/paquetes.php"><i class="fas fa-box"></i>Paquetes <span class="sr-only"></span></a>
+      </li>
+      <li class="nav-item ">
         <a class="nav-link" href="/Logs/index.php"><i class="fas fa-clipboard-list"></i>Logs del sistema <span class="sr-only"></span></a>
       </li>
       <?php } ?>

--- a/database/migrations/20241018_000002_create_paquetes_table.sql
+++ b/database/migrations/20241018_000002_create_paquetes_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `Paquetes` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `nombre` VARCHAR(100) NOT NULL,
+    `primer_pago_monto` DECIMAL(10,2) NOT NULL,
+    `saldo_adicional` DECIMAL(10,2) NOT NULL,
+    `activo` TINYINT(1) NOT NULL DEFAULT 1,
+    `creado_en` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uniq_paquetes_nombre` (`nombre`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/migrations/20241018_000003_add_paquete_id_to_cita.sql
+++ b/database/migrations/20241018_000003_add_paquete_id_to_cita.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `Cita`
+    ADD COLUMN `paquete_id` INT NULL AFTER `Tipo`,
+    ADD CONSTRAINT `fk_cita_paquete`
+        FOREIGN KEY (`paquete_id`) REFERENCES `Paquetes` (`id`)
+        ON DELETE SET NULL
+        ON UPDATE CASCADE;

--- a/index.php
+++ b/index.php
@@ -90,6 +90,7 @@ if ($tablaSolicitudesExiste && in_array($rolUsuario, [3, 4])) {
        DATE(ci.Programado) as Fecha,
        TIME(ci.Programado) as Hora,
        ci.Tipo,
+       ci.FormaPago,
        es.name as Estatus,
        COALESCE(n.saldo_paquete, 0) AS saldo_paquete" . $selectSolicitudesReprogramacion . $selectSolicitudesCancelacion . "
 FROM Cita ci
@@ -114,9 +115,9 @@ ORDER BY ci.Programado ASC;";
                 <th>Paciente</th>
                 <th>Psicólogo</th>
                 <th>Costo</th>
-
                 <th>Hora</th>
                 <th>Tipo</th>
+                <th>Forma de pago</th>
                 <th>Estatus</th>
                 <th>Solicitudes de reprogramación</th>
                 <th>Solicitudes de cancelación</th>
@@ -135,6 +136,7 @@ ORDER BY ci.Programado ASC;";
               $badgeClassCancelacion = $pendientesCancelacion > 0 ? 'badge bg-warning text-dark' : 'badge bg-secondary';
 
               $reprogramarTexto = ($rolUsuario == 1) ? 'Solicitar reprogramación' : 'Reprogramar';
+              $formaPagoRegistrada = isset($row['FormaPago']) ? trim((string) $row['FormaPago']) : '';
               $botones = [];
               if ($rolUsuario == 1 && $pendientesReprogramacion > 0) {
                 $botones[] = '<button class="btn btn-secondary btn-sm" disabled>Solicitud pendiente</button>';
@@ -152,7 +154,9 @@ ORDER BY ci.Programado ASC;";
                 $botones[] = '<button class="btn btn-danger btn-sm" onclick="actualizarCita(' . $row['id'] . ',1)">Cancelar</button>';
               }
 
-              if (date('Y-m-d', strtotime($row['Fecha'])) == $hoy && ($row['Estatus'] == 'Creada' || $row['Estatus'] == 'Reprogramado')) {
+              if ($formaPagoRegistrada !== '') {
+                $botones[] = '<span class="badge bg-success">Pago registrado</span>';
+              } elseif (date('Y-m-d', strtotime($row['Fecha'])) == $hoy && ($row['Estatus'] == 'Creada' || $row['Estatus'] == 'Reprogramado')) {
                 $onclickPago = sprintf(
                   'actualizarCitaPago(%d, %d, %s, %d, %s, %s)',
                   $row['id'],
@@ -173,6 +177,8 @@ ORDER BY ci.Programado ASC;";
               echo '<td>' . $row['costo'] . '</td>';
               echo '<td>' . $row['Hora'] . '</td>';
               echo '<td>' . $row['Tipo'] . '</td>';
+              $formaPagoTexto = $formaPagoRegistrada !== '' ? $formaPagoRegistrada : 'Sin registrar';
+              echo '<td>' . htmlspecialchars($formaPagoTexto, ENT_QUOTES, 'UTF-8') . '</td>';
               echo '<td>' . $row['Estatus'] . '</td>';
               echo '<td><span class="' . $badgeClassReprogramacion . '">' . $textoBadgeReprogramacion . '</span></td>';
               echo '<td><span class="' . $badgeClassCancelacion . '">' . $textoBadgeCancelacion . '</span></td>';
@@ -257,6 +263,12 @@ ORDER BY ci.Programado ASC;";
               </select>
             </div>
             <div class="form-group">
+              <label for="paqueteSelect">Paquete</label>
+              <select name="paquete" id="paqueteSelect" class="form-select" onchange="handlePaqueteChange()">
+                <option value="">Sin paquete</option>
+              </select>
+            </div>
+            <div class="form-group">
               <label for="citaDia"> Día de la cita</label>
               <input type="datetime-local" id="citaDia" name="citaDia" class="form-select" onchange="updateResumen()">
             </div>
@@ -293,7 +305,24 @@ ORDER BY ci.Programado ASC;";
               </div>
               <div class="form-group">
                 <label for="resumenCosto">Costo</label>
-                <input type="number" name="resumenCosto" id="resumenCosto" class="form-control" >
+                <input type="number" name="resumenCosto" id="resumenCosto" class="form-control" min="0" step="0.01">
+              </div>
+              <div class="form-group">
+                <label for="resumenPaquete">Paquete</label>
+                <input type="text" name="resumenPaquete" id="resumenPaquete" class="form-control" value="Sin paquete" readonly>
+                <input type="hidden" name="sendIdPaquete" id="sendIdPaquete">
+              </div>
+              <div class="form-group d-none" id="grupoMetodoPaquete">
+                <label for="paqueteMetodo">Método del primer pago</label>
+                <select name="paqueteMetodo" id="paqueteMetodo" class="form-select">
+                  <option value="">Selecciona una opción</option>
+                  <option value="Efectivo">Efectivo</option>
+                  <option value="Transferencia">Transferencia</option>
+                </select>
+              </div>
+              <div class="form-group d-none" id="grupoSaldoPaquete">
+                <label for="resumenSaldoPaquete">Saldo adicional</label>
+                <input type="text" id="resumenSaldoPaquete" class="form-control" readonly>
               </div>
               <div class="form-group">
                 <label for="resumenFecha">Fecha de la Cita</label>
@@ -435,6 +464,14 @@ include 'Modulos/footer.php';
   const formatoMoneda = new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' });
   const METODOS_PAGO = ['Efectivo', 'Transferencia', 'Tarjeta'];
   const METODO_SALDO = 'Saldo';
+  const paqueteSelect = document.getElementById('paqueteSelect');
+  const resumenPaqueteInput = document.getElementById('resumenPaquete');
+  const sendIdPaqueteInput = document.getElementById('sendIdPaquete');
+  const paqueteMetodoSelect = document.getElementById('paqueteMetodo');
+  const grupoMetodoPaquete = document.getElementById('grupoMetodoPaquete');
+  const grupoSaldoPaquete = document.getElementById('grupoSaldoPaquete');
+  const resumenSaldoPaqueteInput = document.getElementById('resumenSaldoPaquete');
+  const paquetesDisponibles = new Map();
 
   function obtenerTotalesPagos() {
     const totales = {
@@ -515,6 +552,73 @@ include 'Modulos/footer.php';
     } else {
       agregarPagoSaldoBtn.removeAttribute('disabled');
     }
+  }
+
+  function obtenerPaqueteSeleccionado() {
+    if (!paqueteSelect) {
+      return null;
+    }
+    const paqueteId = paqueteSelect.value;
+    if (!paqueteId) {
+      return null;
+    }
+    return paquetesDisponibles.get(paqueteId) || null;
+  }
+
+  function aplicarPaqueteSeleccionado() {
+    if (!resumenPaqueteInput || !sendIdPaqueteInput) {
+      return;
+    }
+
+    const paqueteSeleccionado = obtenerPaqueteSeleccionado();
+    const resumenCostoInput = document.getElementById('resumenCosto');
+    const costosSelect = document.getElementById('costosSelect');
+
+    if (paqueteSeleccionado) {
+      resumenPaqueteInput.value = paqueteSeleccionado.nombre;
+      sendIdPaqueteInput.value = paqueteSeleccionado.id;
+      if (resumenCostoInput) {
+        resumenCostoInput.value = Number(paqueteSeleccionado.primer_pago_monto).toFixed(2);
+        resumenCostoInput.setAttribute('readonly', 'readonly');
+      }
+      if (grupoMetodoPaquete) {
+        grupoMetodoPaquete.classList.remove('d-none');
+      }
+      if (grupoSaldoPaquete) {
+        grupoSaldoPaquete.classList.remove('d-none');
+      }
+      if (resumenSaldoPaqueteInput) {
+        resumenSaldoPaqueteInput.value = formatoMoneda.format(paqueteSeleccionado.saldo_adicional);
+      }
+      if (paqueteMetodoSelect && !paqueteMetodoSelect.value) {
+        paqueteMetodoSelect.value = 'Efectivo';
+      }
+    } else {
+      resumenPaqueteInput.value = 'Sin paquete';
+      sendIdPaqueteInput.value = '';
+      if (resumenCostoInput) {
+        if (costosSelect && costosSelect.selectedIndex >= 0) {
+          resumenCostoInput.value = costosSelect.options[costosSelect.selectedIndex].value;
+        }
+        resumenCostoInput.removeAttribute('readonly');
+      }
+      if (grupoMetodoPaquete) {
+        grupoMetodoPaquete.classList.add('d-none');
+      }
+      if (grupoSaldoPaquete) {
+        grupoSaldoPaquete.classList.add('d-none');
+      }
+      if (resumenSaldoPaqueteInput) {
+        resumenSaldoPaqueteInput.value = '';
+      }
+      if (paqueteMetodoSelect) {
+        paqueteMetodoSelect.value = '';
+      }
+    }
+  }
+
+  function handlePaqueteChange() {
+    aplicarPaqueteSeleccionado();
   }
 
   function handleMontoChange(index, valor) {
@@ -881,6 +985,15 @@ function enviarFormularioJSON() {
       return false;
     }
 
+    const paqueteSeleccionado = sendIdPaqueteInput ? sendIdPaqueteInput.value : '';
+    if (paqueteSeleccionado) {
+      const metodoPaquete = paqueteMetodoSelect ? paqueteMetodoSelect.value : '';
+      if (metodoPaquete !== 'Efectivo' && metodoPaquete !== 'Transferencia') {
+        alert('Selecciona la forma de pago para el paquete (efectivo o transferencia).');
+        return false;
+      }
+    }
+
     // Si todo es válido, enviar el formulario
 enviarFormularioJSON();
 
@@ -892,23 +1005,39 @@ enviarFormularioJSON();
     const idEmpleado = document.getElementById('idEmpleado');
     const costosSelect = document.getElementById('costosSelect');
     const citaDia = document.getElementById('citaDia');
+    const resumenCostoInput = document.getElementById('resumenCosto');
 
-    document.getElementById('resumenCliente').value = nameSelect.options[nameSelect.selectedIndex].text;
-    document.getElementById('sendIdCliente').value = nameSelect.options[nameSelect.selectedIndex].value;
-    document.getElementById('resumenPsicologo').value = idEmpleado.options[idEmpleado.selectedIndex].text;
-    document.getElementById('sendIdPsicologo').value = idEmpleado.options[idEmpleado.selectedIndex].value;
-    var texts = costosSelect.options[costosSelect.selectedIndex].text;
-    var textoLimpio = texts.replace(/[0-9:$.]/g, '');
-    document.getElementById('resumenTipo').value = textoLimpio;
-    document.getElementById('resumenCosto').value = costosSelect.options[costosSelect.selectedIndex].value;
-    document.getElementById('resumenFecha').value = citaDia.value;
+    if (nameSelect && nameSelect.selectedIndex >= 0) {
+      document.getElementById('resumenCliente').value = nameSelect.options[nameSelect.selectedIndex].text;
+      document.getElementById('sendIdCliente').value = nameSelect.options[nameSelect.selectedIndex].value;
+    }
 
+    if (idEmpleado && idEmpleado.selectedIndex >= 0) {
+      document.getElementById('resumenPsicologo').value = idEmpleado.options[idEmpleado.selectedIndex].text;
+      document.getElementById('sendIdPsicologo').value = idEmpleado.options[idEmpleado.selectedIndex].value;
+    }
+
+    if (costosSelect && costosSelect.selectedIndex >= 0) {
+      const textoOpcion = costosSelect.options[costosSelect.selectedIndex].text;
+      const textoLimpio = textoOpcion.replace(/[0-9:$.]/g, '').trim();
+      document.getElementById('resumenTipo').value = textoLimpio;
+      if (resumenCostoInput && !(paqueteSelect && paqueteSelect.value)) {
+        resumenCostoInput.value = costosSelect.options[costosSelect.selectedIndex].value;
+      }
+    }
+
+    if (citaDia) {
+      document.getElementById('resumenFecha').value = citaDia.value;
+    }
+
+    aplicarPaqueteSeleccionado();
     revisarCita();
   }
   function loadAll() {
     loadCostos();
     loadNames();
     loadEmpleados();
+    loadPaquetes();
 
   }
   function loadCostos() {
@@ -938,6 +1067,49 @@ enviarFormularioJSON();
       }
     };
     xhr.send();
+  }
+
+  function loadPaquetes() {
+    if (!paqueteSelect) {
+      return;
+    }
+
+    fetch('Modulos/getPaquetes.php')
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Error al cargar paquetes');
+        }
+        return response.json();
+      })
+      .then((paquetes) => {
+        paquetesDisponibles.clear();
+        paqueteSelect.innerHTML = '<option value="">Sin paquete</option>';
+
+        if (Array.isArray(paquetes)) {
+          paquetes.forEach((paquete) => {
+            const idCadena = String(paquete.id);
+            const paqueteNormalizado = {
+              id: idCadena,
+              nombre: paquete.nombre,
+              primer_pago_monto: parseFloat(paquete.primer_pago_monto),
+              saldo_adicional: parseFloat(paquete.saldo_adicional),
+            };
+            paquetesDisponibles.set(idCadena, paqueteNormalizado);
+
+            const option = document.createElement('option');
+            option.value = idCadena;
+            option.textContent = `${paqueteNormalizado.nombre} - pago ${formatoMoneda.format(paqueteNormalizado.primer_pago_monto)} / saldo ${formatoMoneda.format(paqueteNormalizado.saldo_adicional)}`;
+            paqueteSelect.appendChild(option);
+          });
+        }
+
+        aplicarPaqueteSeleccionado();
+      })
+      .catch(() => {
+        paquetesDisponibles.clear();
+        paqueteSelect.innerHTML = '<option value="">Sin paquete</option>';
+        aplicarPaqueteSeleccionado();
+      });
   }
   function loadEmpleados() {
     const xhr = new XMLHttpRequest();

--- a/procesar_cita.php
+++ b/procesar_cita.php
@@ -15,23 +15,68 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
 
     require_once 'conexion.php';
     require_once __DIR__ . '/Modulos/logger.php';
+    require_once __DIR__ . '/Modulos/saldo_pacientes.php';
+
     $conn = conectar();
     $conn->set_charset('utf8');
 
-    $sql = "INSERT INTO Cita (id, IdNino, IdUsuario, idGenerado, fecha, costo, Programado, Estatus, Tipo)
-                VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?)";
-
-    $idCliente = $_POST['sendIdCliente'];
-    $idPsicologo = $_POST['sendIdPsicologo'];
-    $tipo = $_POST['resumenTipo'];
+    $idCliente = isset($_POST['sendIdCliente']) ? (int) $_POST['sendIdCliente'] : 0;
+    $idPsicologo = isset($_POST['sendIdPsicologo']) ? (int) $_POST['sendIdPsicologo'] : 0;
+    $tipo = trim($_POST['resumenTipo']);
     $fechaCita = $_POST['resumenFecha'];
-    $idGenerado = $_SESSION['id'];
+    $idGenerado = isset($_SESSION['id']) ? (int) $_SESSION['id'] : null;
     $estatus = 2;
     $fechaActual = date('Y-m-d H:i:s');
-    $costo = $_POST['resumenCosto'];
+    $costo = (float) $_POST['resumenCosto'];
+
+    $paqueteId = isset($_POST['sendIdPaquete']) && $_POST['sendIdPaquete'] !== '' ? (int) $_POST['sendIdPaquete'] : null;
+    $paqueteMetodo = isset($_POST['paqueteMetodo']) ? trim($_POST['paqueteMetodo']) : '';
+    $paqueteInfo = null;
+
+    if ($paqueteId !== null) {
+        $metodosPermitidos = ['Efectivo', 'Transferencia'];
+        if (!in_array($paqueteMetodo, $metodosPermitidos, true)) {
+            echo json_encode(['success' => false, 'message' => 'Selecciona un método de pago válido para el paquete.']);
+            $conn->close();
+            exit;
+        }
+
+        $stmtPaquete = $conn->prepare('SELECT id, nombre, primer_pago_monto, saldo_adicional FROM Paquetes WHERE id = ? AND activo = 1');
+        if (!$stmtPaquete) {
+            echo json_encode(['success' => false, 'message' => 'No fue posible consultar el paquete seleccionado.']);
+            $conn->close();
+            exit;
+        }
+
+        $stmtPaquete->bind_param('i', $paqueteId);
+        $stmtPaquete->execute();
+        $stmtPaquete->bind_result($paqueteDbId, $paqueteNombre, $paquetePrimerPago, $paqueteSaldoAdicional);
+        if ($stmtPaquete->fetch()) {
+            $paqueteInfo = [
+                'id' => (int) $paqueteDbId,
+                'nombre' => $paqueteNombre,
+                'primer_pago_monto' => (float) $paquetePrimerPago,
+                'saldo_adicional' => (float) $paqueteSaldoAdicional,
+            ];
+        }
+        $stmtPaquete->close();
+
+        if ($paqueteInfo === null) {
+            echo json_encode(['success' => false, 'message' => 'El paquete seleccionado no está disponible.']);
+            $conn->close();
+            exit;
+        }
+    } else {
+        $paqueteMetodo = '';
+    }
 
     // Revisión rápida: evitar duplicados con misma fecha y usuario
-    $check = $conn->prepare("SELECT COUNT(*) FROM Cita WHERE IdNino = ? AND Programado = ?");
+    $check = $conn->prepare('SELECT COUNT(*) FROM Cita WHERE IdNino = ? AND Programado = ?');
+    if (!$check) {
+        echo json_encode(['success' => false, 'message' => 'No fue posible validar la disponibilidad de la cita.']);
+        $conn->close();
+        exit;
+    }
     $check->bind_param('is', $idCliente, $fechaCita);
     $check->execute();
     $check->bind_result($count);
@@ -39,32 +84,91 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $check->close();
     if ($count > 0) {
         echo json_encode(['success' => false, 'message' => 'Ya existe una cita registrada para este paciente en esa fecha y hora.']);
+        $conn->close();
         exit;
     }
 
-    $stmt = $conn->prepare($sql);
-    $stmt->bind_param('iiisdsis', $idCliente, $idPsicologo, $idGenerado, $fechaActual, $costo, $fechaCita, $estatus, $tipo);
-    $stmt->execute();
-    $nuevaCitaId = $conn->insert_id;
-    $stmt->close();
+    $conn->begin_transaction();
 
-    registrarLog(
-        $conn,
-        $idGenerado,
-        'citas',
-        'crear',
-        sprintf(
-            'Se creó la cita #%d para el paciente %d con el psicólogo %d programada el %s.',
-            $nuevaCitaId,
-            $idCliente,
-            $idPsicologo,
-            $fechaCita
-        ),
-        'Cita',
-        (string) $nuevaCitaId
-    );
+    try {
+        $sql = 'INSERT INTO Cita (IdNino, IdUsuario, idGenerado, fecha, costo, Programado, Estatus, Tipo, paquete_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        $stmt = $conn->prepare($sql);
+        if (!$stmt) {
+            throw new Exception('No fue posible preparar la creación de la cita.');
+        }
 
-    echo json_encode(['success' => true]);
+        $stmt->bind_param('iiisdsisi', $idCliente, $idPsicologo, $idGenerado, $fechaActual, $costo, $fechaCita, $estatus, $tipo, $paqueteId);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            throw new Exception('No fue posible guardar la cita.');
+        }
+
+        $nuevaCitaId = $conn->insert_id;
+        $stmt->close();
+
+        $descripcionPaquete = '';
+
+        if ($paqueteInfo !== null) {
+            $montoInicial = (float) $paqueteInfo['primer_pago_monto'];
+            $saldoOtorgado = (float) $paqueteInfo['saldo_adicional'];
+
+            $stmtPago = $conn->prepare('INSERT INTO CitaPagos (cita_id, metodo, monto, registrado_por) VALUES (?, ?, ?, ?)');
+            if (!$stmtPago) {
+                throw new Exception('No fue posible registrar el pago inicial del paquete.');
+            }
+            $stmtPago->bind_param('isdi', $nuevaCitaId, $paqueteMetodo, $montoInicial, $idGenerado);
+            if (!$stmtPago->execute()) {
+                $stmtPago->close();
+                throw new Exception('Ocurrió un error al guardar el pago inicial del paquete.');
+            }
+            $stmtPago->close();
+
+            $formaPagoPaquete = sprintf('Paquete (%s)', $paqueteMetodo);
+            $stmtActualizar = $conn->prepare('UPDATE Cita SET FormaPago = ? WHERE id = ?');
+            if ($stmtActualizar) {
+                $stmtActualizar->bind_param('si', $formaPagoPaquete, $nuevaCitaId);
+                $stmtActualizar->execute();
+                $stmtActualizar->close();
+            }
+
+            if ($saldoOtorgado > 0) {
+                if (!ajustarSaldoPaciente($conn, $idCliente, $saldoOtorgado)) {
+                    throw new Exception('No fue posible actualizar el saldo disponible del paciente.');
+                }
+            }
+
+            $descripcionPaquete = sprintf(
+                ' Se aplicó el paquete "%s" con pago inicial de %.2f (%s) y saldo adicional de %.2f.',
+                $paqueteInfo['nombre'],
+                $montoInicial,
+                $paqueteMetodo,
+                $saldoOtorgado
+            );
+        }
+
+        registrarLog(
+            $conn,
+            $idGenerado,
+            'citas',
+            'crear',
+            sprintf(
+                'Se creó la cita #%d para el paciente %d con el psicólogo %d programada el %s.',
+                $nuevaCitaId,
+                $idCliente,
+                $idPsicologo,
+                $fechaCita
+            ) . $descripcionPaquete,
+            'Cita',
+            (string) $nuevaCitaId
+        );
+
+        $conn->commit();
+        echo json_encode(['success' => true]);
+    } catch (Exception $e) {
+        $conn->rollback();
+        echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+    }
+
     $conn->close();
 } else {
     echo json_encode(['success' => false, 'message' => 'Método no permitido']);


### PR DESCRIPTION
## Summary
- add a configuration page and endpoints to create and toggle patient packages
- surface package selection in the scheduling form with automatic balance handling and payment method capture
- record initial package payments during appointment creation and extend the schema to persist package metadata

## Testing
- php -l Modulos/getPaquetes.php
- php -l Configuracion/paquetes.php
- php -l Configuracion/guardar_paquete.php
- php -l Configuracion/toggle_paquete.php
- php -l Modulos/head.php
- php -l index.php
- php -l procesar_cita.php

------
https://chatgpt.com/codex/tasks/task_e_68d9805adcfc832295be71482fdb080b