### PR TITLE
Restrict balance top-ups to admin and coordinator roles

### DIFF
--- a/Clientes/agregarSaldo.php
+++ b/Clientes/agregarSaldo.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+if (!isset($_SESSION['id'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autenticado.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+$rolUsuario = isset($_SESSION['rol']) ? (int) $_SESSION['rol'] : 0;
+if (!in_array($rolUsuario, [3, 5], true)) {
+    http_response_code(403);
+    echo json_encode(['error' => 'No tienes permisos para agregar saldo.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Método no permitido.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+$payload = json_decode((string) file_get_contents('php://input'), true);
+if (!is_array($payload)) {
+    $payload = $_POST;
+}
+
+$ninoId = isset($payload['nino_id']) ? filter_var($payload['nino_id'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) : null;
+$monto = isset($payload['monto']) ? (float) $payload['monto'] : null;
+$comentario = isset($payload['comentario']) ? trim((string) $payload['comentario']) : '';
+
+if ($ninoId === null || $monto === null) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Los parámetros nino_id y monto son obligatorios.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+if (!is_finite($monto) || $monto <= 0) {
+    http_response_code(422);
+    echo json_encode(['error' => 'El monto debe ser mayor que cero.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+require_once __DIR__ . '/../conexion.php';
+require_once __DIR__ . '/../Modulos/saldo_pacientes.php';
+require_once __DIR__ . '/../Modulos/logger.php';
+
+$conn = conectar();
+if (!$conn) {
+    http_response_code(500);
+    echo json_encode(['error' => 'No fue posible conectar con la base de datos.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT name, saldo_paquete FROM nino WHERE id = ?');
+if ($stmt === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'No fue posible preparar la consulta del paciente.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    $conn->close();
+    exit;
+}
+
+$stmt->bind_param('i', $ninoId);
+
+if (!$stmt->execute()) {
+    http_response_code(500);
+    echo json_encode(['error' => 'No fue posible ejecutar la consulta del paciente.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    $stmt->close();
+    $conn->close();
+    exit;
+}
+
+$stmt->bind_result($pacienteNombre, $saldoActual);
+if (!$stmt->fetch()) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Paciente no encontrado.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    $stmt->close();
+    $conn->close();
+    exit;
+}
+
+$stmt->close();
+
+$saldoActual = (float) $saldoActual;
+$conn->begin_transaction();
+
+try {
+    if (!ajustarSaldoPaciente($conn, $ninoId, $monto)) {
+        throw new RuntimeException('No fue posible actualizar el saldo del paciente.');
+    }
+
+    $nuevoSaldo = $saldoActual + $monto;
+
+    $descripcion = sprintf(
+        'Se agregaron %s al saldo del paciente %s. Nuevo saldo: %s.',
+        number_format($monto, 2),
+        $pacienteNombre,
+        number_format($nuevoSaldo, 2)
+    );
+
+    if ($comentario !== '') {
+        $descripcion .= ' Comentario: ' . $comentario;
+    }
+
+    registrarLog(
+        $conn,
+        (int) $_SESSION['id'],
+        'pacientes',
+        'agregar_saldo',
+        $descripcion,
+        'Paciente',
+        (string) $ninoId
+    );
+
+    $conn->commit();
+
+    echo json_encode([
+        'success' => true,
+        'nuevoSaldo' => $nuevoSaldo,
+        'paciente' => $pacienteNombre,
+    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+} catch (Throwable $exception) {
+    $conn->rollback();
+    http_response_code(500);
+    echo json_encode(['error' => $exception->getMessage()], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+} finally {
+    $conn->close();
+}

--- a/Clientes/getpaciente.php
+++ b/Clientes/getpaciente.php
@@ -1,16 +1,75 @@
 <?php
+
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+
 require_once __DIR__ . '/../conexion.php';
+
 $conn = conectar();
+if (!$conn) {
+    http_response_code(500);
+    echo json_encode(['error' => 'No fue posible conectar con la base de datos.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
 
-$id = $_GET['idtutor'];
-$name = $_GET['name'];
-$sql = "SELECT id, name, edad, activo, idtutor, `Observacion`, `FechaIngreso` FROM nino WHERE idtutor = ? AND name = ?";
-$stmt = $conn->prepare($sql);
-$stmt->bind_param("is", $id, $name);
-$stmt->execute();
-$result = $stmt->get_result();
-$user = $result->fetch_assoc();
-echo json_encode($user);
+$ninoId = null;
+if (isset($_GET['nino_id'])) {
+    $ninoId = filter_var($_GET['nino_id'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+}
 
+$idTutor = null;
+$nombre = null;
+if ($ninoId === null) {
+    if (isset($_GET['idtutor'])) {
+        $idTutor = filter_var($_GET['idtutor'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+    }
+    if (isset($_GET['name'])) {
+        $nombre = trim((string) $_GET['name']);
+    }
+
+    if ($idTutor === null || $nombre === null || $nombre === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'Los parámetros idtutor y name son obligatorios.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $conn->close();
+        exit;
+    }
+}
+
+if ($ninoId !== null) {
+    $stmt = $conn->prepare('SELECT id, name, edad, activo, idtutor, Observacion, FechaIngreso, saldo_paquete FROM nino WHERE id = ?');
+    if ($stmt === false) {
+        http_response_code(500);
+        echo json_encode(['error' => 'No fue posible preparar la consulta del paciente.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $conn->close();
+        exit;
+    }
+
+    $stmt->bind_param('i', $ninoId);
+} else {
+    $stmt = $conn->prepare('SELECT id, name, edad, activo, idtutor, Observacion, FechaIngreso, saldo_paquete FROM nino WHERE idtutor = ? AND name = ?');
+    if ($stmt === false) {
+        http_response_code(500);
+        echo json_encode(['error' => 'No fue posible preparar la consulta del paciente.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $conn->close();
+        exit;
+    }
+
+    $stmt->bind_param('is', $idTutor, $nombre);
+}
+
+if (!$stmt->execute()) {
+    http_response_code(500);
+    echo json_encode(['error' => 'No fue posible ejecutar la consulta del paciente.'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    $stmt->close();
+    $conn->close();
+    exit;
+}
+
+$resultado = $stmt->get_result();
+$paciente = $resultado->fetch_assoc();
+
+$stmt->close();
 $conn->close();
-?>
+
+echo json_encode($paciente ?: null, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);


### PR DESCRIPTION
## Summary
- hide the "Agregar saldo" action in the client list for users without coordinator or admin roles
- block the agregarSaldo endpoint for users whose roles are not coordinator (5) or admin (3)

## Testing
- php -l Clientes/index.php
- php -l Clientes/agregarSaldo.php

------
https://chatgpt.com/codex/tasks/task_e_68e672d7f3908322a69cc2232ffa17aa