### PR TITLE
Oculta reuniones vencidas en calendario y añade modal de reuniones en index

### DIFF
--- a/api/citas_calendario.php
+++ b/api/citas_calendario.php
@@ -176,6 +176,11 @@ $condicionesReunion = [];
 $tiposReunion = '';
 $parametrosReunion = [];
 
+$ahora = new DateTime('now', $timezone);
+$condicionesReunion[] = 'ri.fin >= ?';
+$tiposReunion .= 's';
+$parametrosReunion[] = $ahora->format('Y-m-d H:i:s');
+
     if ($fechaInicio !== null) {
         $condicionesReunion[] = 'ri.fin >= ?';
         $tiposReunion .= 's';


### PR DESCRIPTION
### Motivation
- Evitar que reuniones internas cuyo fin ya pasó sigan apareciendo en el calendario y ofrecer acceso rápido desde la pantalla principal a las reuniones vigentes.

### Description
- En `api/citas_calendario.php` se agregó filtro por fecha/hora actual (`ri.fin >= ahora`) para excluir reuniones ya vencidas de la consulta que genera los eventos del calendario.
- En `index.php` se implementó una consulta de reuniones programadas vigentes y se calculó el total (`$reunionesProgramadas`, `$reunionesProgramadasTotal`).
- Se añadió en la cabecera de la tarjeta de "Citas" un botón "Reuniones programadas" que muestra un badge con el conteo cuando hay reuniones y abre un modal.
- Se agregó un modal en `index.php` que lista las reuniones vigentes (ID, título, inicio, fin y psicólogas) y muestra un mensaje cuando no hay registros.

### Testing
- Se ejecutó `php -l api/citas_calendario.php` y `php -l index.php` y ambos pasaron sin errores de sintaxis.
- Se levantó un servidor de desarrollo con `php -S` y se capturó una captura visual de `index.php` mediante Playwright para validar el botón y el modal; la comprobación visual se generó correctamente.
- Las comprobaciones automáticas realizadas (lint de PHP y la captura visual) concluyeron con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b18d65888322b44f6f93a811c88b)